### PR TITLE
build_cascade_events: 별표 본문 법률 인용 패턴 multi-group 일반화

### DIFF
--- a/build_cascade_events.py
+++ b/build_cascade_events.py
@@ -49,8 +49,19 @@ from build_3tier_map import LAW_GROUPS as _SHARED_LAW_GROUPS
 # 별표 제목에서 모법 조문 인용 추출
 # 예: "(제91조제1항관련)", "[제18조제1항관련]", "(제46조제1항ㆍ제46조의2제1항 관련)"
 TABLE_ARTICLE_PAT = re.compile(r"제(\d+(?:의\d+)?)조")
-# 별표 본문에서 "법 제X조" / "도로교통법 제X조" 인용 추출 (법률 조문 직접 인용)
+# 별표 본문에서 "법 제X조" / "{법령명} 제X조" 인용 추출 (법률 조문 직접 인용)
+# 기본은 road, main()에서 --group에 따라 재컴파일.
 LAW_REF_IN_TABLE = re.compile(r"(?:도로교통)?법\s*제(\d+(?:의\d+)?)조")
+
+
+def _compile_law_ref_in_table_pat(group_laws):
+    """별표 본문의 자기 그룹 법률 인용 매칭. "법 제X조" 약식 + "{법령명} 제X조" 명시 모두 잡음.
+    법령명 내부 공백 \\s* 유연 매칭."""
+    law_name = (group_laws.get("법률") or {}).get("법령명", "")
+    if not law_name:
+        return re.compile(r"법\s*제(\d+(?:의\d+)?)조")
+    flexible = r"\s*".join(re.escape(p) for p in law_name.split())
+    return re.compile(r"(?:" + flexible + r"|법)\s*제(\d+(?:의\d+)?)조")
 
 
 # ─────────────────────────────────────────────────────────
@@ -207,8 +218,9 @@ def main():
 
     # 그룹별 법령명 동적화 — 「법령명」 인용 매칭 + 본문/부칙 dict 키 모두 사용
     group_laws = _SHARED_LAW_GROUPS[args.group]
-    global LAWNAME_PAT
+    global LAWNAME_PAT, LAW_REF_IN_TABLE
     LAWNAME_PAT = _compile_lawname_pat(group_laws)
+    LAW_REF_IN_TABLE = _compile_law_ref_in_table_pat(group_laws)
     # 법령유형 → 법령명 (그룹에 없는 유형은 키 누락. 단일 법률 그룹은 시행령·시행규칙 없음)
     type_to_name = {lt: info["법령명"] for lt, info in group_laws.items() if info.get("법령명")}
     history_path = os.path.join(DATA_DIR, f"article_history{suffix}.json")


### PR DESCRIPTION
## Summary
- LAW_REF_IN_TABLE 정규식을 그룹 법률 법령명 기반으로 동적 컴파일
- 법령명 내부 공백 \s* 유연 매칭 (PR #22와 동일 패턴)
- road는 (도로교통법|법) 모두 매칭 유지, 다른 그룹은 자기 법령명 + "법" 양쪽 매칭

## Why
PR #22 Codex 사후검증 권장 사항. 기존 `(?:도로교통)?법\s*제` 패턴은 도교법 외 그룹의 별표 본문에서 "자동차관리법 제X조" 같은 명시 인용을 못 잡아 별표→법률 매핑 누락 발생.

## Test plan
- [x] road 빌드 — 94 이벤트, 본문인용 22건·매핑실패 11건 동일 (회귀 없음)
- [x] tlspc 빌드 — 16 이벤트 정상 (별표 0개 그룹이라 본문인용 효과 미미하나 graceful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)