### PR TITLE
Phase 3 PR-D — content_tier 구분자 + viewer 단순 카드 표지

### DIFF
--- a/tutor/build_tutor_content.py
+++ b/tutor/build_tutor_content.py
@@ -1373,6 +1373,9 @@ def build_other_group_article_card(selection, use_llm=True):
         'rank': 1,
         'card_type': 'article',
         'group': group,
+        # Phase 3 PR-D — content_tier로 도교법 6필드 풀 카드와 다른 그룹 단순 2필드 카드 구분.
+        # llm_status='ok'가 두 케이스를 섞지 않도록 명시 표지 (Codex PR-C 권장).
+        'content_tier': 'simple',
         'selection_basis': selection.get('basis', {}),
         'law_info': {
             '법령유형': '법률',

--- a/tutor/index.html
+++ b/tutor/index.html
@@ -322,8 +322,12 @@ function renderMainCard(card) {
     : '';
 
   if (llmOk) {
+    // Phase 3 PR-D — 단순 카드(content_tier='simple')는 도교법 풀 카드와 다른 작은 표지
+    const tierBadge = card.content_tier === 'simple'
+      ? '<span class="badge cat" style="background:#e0e7ff;color:#3730a3;font-size:10px" title="다른 그룹 단순 콘텐츠 — 도교법 6필드 풀 콘텐츠와 다름">📘 간략판</span>'
+      : '';
     return '<article class="card ' + lawClass + '">'
-      + '<div class="card-header">' + badge + groupBadge + catBadge + dateInfo + '</div>'
+      + '<div class="card-header">' + badge + groupBadge + tierBadge + catBadge + dateInfo + '</div>'
       + '<div class="jo-label">📖 ' + esc(lc.source_article || (lawName + ' 제' + jo + '조')) + '</div>'
       + '<h2 class="oneliner">' + esc(String(lc.oneliner || '').replace(/[.\s]+$/, '')) + '</h2>'
       + '<p class="explanation">' + esc(lc.explanation) + '</p>'
@@ -562,16 +566,18 @@ function renderCard(card) {
   if (card && card.card_type === 'case') return renderCaseCard(card);
   // 순서(R9): 메인 → 조문 원문 → 법리분석 → 학습포인트
   //          → 관련판례 → 핵심쟁점 → 참고자료 → 법령본문보기
+  // Phase 3 PR-D — content_tier='simple' (다른 그룹 단순 카드)는 도교법 풀 콘텐츠용 섹션 차단 (자료 없음).
   const lc = card.learning_content || {};
   const llmOk = isLlmOk(card.llm_status);
+  const isFull = llmOk && card.content_tier !== 'simple';
   return [
     renderMainCard(card),
     renderArticleText(card),
-    llmOk ? renderAnalysis(card) : '',
-    llmOk ? renderStudy(lc) : '',
-    llmOk ? renderCases(card) : '',
-    llmOk ? renderIssues(lc) : '',
-    llmOk ? renderRefs(card) : '',
+    isFull ? renderAnalysis(card) : '',
+    isFull ? renderStudy(lc) : '',
+    isFull ? renderCases(card) : '',
+    isFull ? renderIssues(lc) : '',
+    isFull ? renderRefs(card) : '',
     renderViewLaw(card)
   ].join('');
 }


### PR DESCRIPTION
## Summary
- card에 content_tier 필드 추가 — 도교법 6필드 풀 카드와 다른 그룹 단순 2필드 카드 구분
- viewer 작은 📘 간략판 배지 + 도교법 전용 섹션 차단
- PR-C Codex 사후검증 권장 1번 반영

## Why
PR-C 머지 후 llm_status='ok'가 두 종류 카드(풀·단순)를 섞었음. viewer는 빈 필드 조용히 숨겨 화면은 안 깨졌으나 데이터 의미·디버깅 가시성 모호. content_tier 명시 표지로 분리.

## Test plan
- [x] 도교법 카드: content_tier=None → 풀 섹션 그대로
- [x] 교특법 카드: content_tier='simple' → 간략판 배지·핵심 섹션만

🤖 Generated with [Claude Code](https://claude.com/claude-code)