### PR TITLE
Phase 3 PR-F — 다른 그룹 article 카드에 조문 연혁 추가

### DIFF
--- a/tutor/build_tutor_content.py
+++ b/tutor/build_tutor_content.py
@@ -350,6 +350,56 @@ def _load_other_group_article(group, jo):
     return ((data.get('법률') or {}).get('조문') or {}).get(jo)
 
 
+def _load_other_group_history(group):
+    """Phase 3 PR-F — 다른 그룹 article_history_{group}.json 캐시 로드.
+    조문 연혁(history_evolution) 추출용. JSON 손상 시 None 폴백."""
+    cache = globals().setdefault('_other_history_cache', {})
+    if group not in cache:
+        suffix = '' if group == 'road' else f'_{group}'
+        path = SCRIPT_DIR.parent / 'data' / f'article_history{suffix}.json'
+        if not path.exists():
+            cache[group] = None
+        else:
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    cache[group] = json.load(f)
+            except (json.JSONDecodeError, OSError) as e:
+                print(f"  ⚠️ article_history{suffix}.json 로드 실패: {e}")
+                cache[group] = None
+    return cache[group]
+
+
+def _extract_jo_history(group, jo, max_changes=3):
+    """Phase 3 PR-F — 특정 조문(jo)의 변경 이력 N건 추출 (공포일 desc).
+    반환: [{공포일자, 시행일자, 제개정구분, 제개정이유}, ...] 또는 []."""
+    data = _load_other_group_history(group)
+    if not data:
+        return []
+    law_versions = ((data.get('법령') or {}).get('법률') or {}).get('버전', [])
+    matches = []
+    for v in law_versions:
+        if jo in (v.get('변경조문키') or []):
+            reason = (v.get('제개정이유') or '').strip()
+            if len(reason) > 220:
+                reason = reason[:220].replace('\n', ' ').strip() + '…'
+            matches.append({
+                '공포일자': v.get('공포일자', ''),
+                '시행일자': v.get('시행일자', ''),
+                '제개정구분': v.get('제개정구분', ''),
+                '제개정이유': reason,
+            })
+    matches.sort(key=lambda x: x.get('공포일자', ''), reverse=True)
+    # 같은 공포일자 중복 제거 (article_history는 같은 공포일에 여러 버전 분리 추적할 수 있음)
+    seen, deduped = set(), []
+    for m in matches:
+        pub = m.get('공포일자', '')
+        if pub and pub in seen:
+            continue
+        seen.add(pub)
+        deduped.append(m)
+    return deduped[:max_changes]
+
+
 def _load_study_whitelist():
     """tutor/data/study_whitelist.json 캐시 로드. JSON 손상 시 빈 dict 폴백."""
     cache = globals().setdefault('_wl_cache', {})
@@ -1404,6 +1454,11 @@ def build_other_group_article_card(selection, use_llm=True):
         },
         'llm_status': 'simple_other_group',
     }
+
+    # PR-F: 조문 연혁(history_evolution) 추가 — article_history_{group}.json 활용
+    history = _extract_jo_history(group, jo, max_changes=3)
+    if history:
+        card['history_evolution'] = history
 
     # PR-C: 간단 LLM 콘텐츠 추가 (실패 시 simple_other_group 그대로)
     if use_llm and GEMINI_API_KEY and article_text:

--- a/tutor/index.html
+++ b/tutor/index.html
@@ -561,15 +561,41 @@ function renderCaseCard(card) {
     + '</article>';
 }
 
+// Phase 3 PR-F — 다른 그룹 단순 카드의 조문 연혁 섹션
+function renderOtherGroupHistory(card) {
+  const hist = card.history_evolution;
+  if (!Array.isArray(hist) || hist.length === 0) return '';
+  const lawName = (card.law_info && card.law_info.법령명) || '';
+  const items = hist.map(h => {
+    const pub = h.공포일자 ? fmtDate(h.공포일자) : '';
+    const eff = h.시행일자 ? fmtDate(h.시행일자) : '';
+    const reason = h.제개정이유 || '';
+    const reasonHtml = reason ? '<div style="font-size:13px;color:#374151;margin-top:4px;line-height:1.6">' + esc(reason) + '</div>' : '';
+    return '<div style="padding:10px 12px;border-bottom:1px solid #f3f4f6">'
+      + '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:12px;color:var(--sub)">'
+      + '<span style="font-weight:600;color:var(--text)">공포 ' + esc(pub) + '</span>'
+      + (eff ? '<span>· 시행 ' + esc(eff) + '</span>' : '')
+      + (h.제개정구분 ? '<span class="badge cat" style="background:#fef3c7;color:#92400e;font-size:11px">' + esc(h.제개정구분) + '</span>' : '')
+      + '</div>'
+      + reasonHtml + '</div>';
+  }).join('');
+  return '<details class="section history-evolution" open>'
+    + '<summary>📜 ' + esc(lawName) + ' 최근 개정 ' + hist.length + '건</summary>'
+    + '<div style="background:#fff;border:1px solid var(--border);border-radius:6px;overflow:hidden">' + items + '</div>'
+    + '</details>';
+}
+
 function renderCard(card) {
   // Phase 2: case 카드는 별도 렌더링. card_type 없으면 article 폴백.
   if (card && card.card_type === 'case') return renderCaseCard(card);
   // 순서(R9): 메인 → 조문 원문 → 법리분석 → 학습포인트
   //          → 관련판례 → 핵심쟁점 → 참고자료 → 법령본문보기
   // Phase 3 PR-D — content_tier='simple' (다른 그룹 단순 카드)는 도교법 풀 콘텐츠용 섹션 차단 (자료 없음).
+  // PR-F — 단순 카드에도 history_evolution은 추가 (article_history_{group}.json 자료 기반).
   const lc = card.learning_content || {};
   const llmOk = isLlmOk(card.llm_status);
   const isFull = llmOk && card.content_tier !== 'simple';
+  const isSimple = card.content_tier === 'simple';
   return [
     renderMainCard(card),
     renderArticleText(card),
@@ -578,6 +604,7 @@ function renderCard(card) {
     isFull ? renderCases(card) : '',
     isFull ? renderIssues(lc) : '',
     isFull ? renderRefs(card) : '',
+    isSimple ? renderOtherGroupHistory(card) : '',
     renderViewLaw(card)
   ].join('');
 }


### PR DESCRIPTION
## Summary
- 다른 그룹(교특법·tkga 등) article 카드에 history_evolution 필드 추가 (최근 3건 연혁)
- article_history_{group}.json 활용 — 변경조문키에 jo 포함된 버전 추출
- 공포일 desc 정렬 + 같은 공포일자 dedup + 제개정이유 220자 절단
- viewer renderOtherGroupHistory 섹션 신규

## Why
build_indexes multi-group 풀 확장은 다른 그룹 판례·해설 자료 부재로 가성비 낮음. 자료 있는 article_history만 활용해 카드 가치 한 단계 ↑.

## Test plan
- [x] 교특법 5조 3건 연혁 (2016/2011/2011) + 개정이유 정상
- [x] 여객자동차 운수사업법 21조 3건 (2025/2024/2020, dedup 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)