### PR TITLE
Phase 3 PR-H1 — PWA 기본 (manifest + service-worker + SW 등록)

### DIFF
--- a/generate_viewer.py
+++ b/generate_viewer.py
@@ -485,6 +485,10 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
 <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 <meta http-equiv="Pragma" content="no-cache">
 <meta http-equiv="Expires" content="0">
+<!-- PWA PR-H1 — manifest + theme color -->
+<link rel="manifest" href="manifest.json">
+<meta name="theme-color" content="#1e40af">
+<link rel="apple-touch-icon" href="icons/icon-192.svg">
 <title>{{LAW_TITLE}} 한눈에 — 법률·시행령·시행규칙·별표 통합 비교</title>
 <style>
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700&display=swap');
@@ -2871,6 +2875,15 @@ window.addEventListener('message',e=>{
   url.searchParams.delete('law');
   window.location.href=url.toString();
 });
+
+// PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('service-worker.js', { scope: './' })
+      .then(reg => console.log('SW 등록 OK:', reg.scope))
+      .catch(err => console.warn('SW 등록 실패:', err));
+  });
+}
 </script>
 </body>
 </html>

--- a/icons/icon-192.svg
+++ b/icons/icon-192.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="32" fill="#1e40af"/>
+  <text x="96" y="125" text-anchor="middle" font-size="100" font-family="'Noto Sans KR', sans-serif" font-weight="700" fill="#fff">법</text>
+  <circle cx="148" cy="44" r="14" fill="#fbbf24"/>
+</svg>

--- a/icons/icon-512.svg
+++ b/icons/icon-512.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="86" fill="#1e40af"/>
+  <text x="256" y="334" text-anchor="middle" font-size="266" font-family="'Noto Sans KR', sans-serif" font-weight="700" fill="#fff">법</text>
+  <circle cx="394" cy="118" r="38" fill="#fbbf24"/>
+</svg>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,26 @@
+{
+  "name": "출근길 법령튜터 + 도로교통법 한눈에",
+  "short_name": "법령튜터",
+  "description": "한국도로교통공단 교통안전교육 교수의 출근길 5분 학습 — 매일 5장의 법령 카드 + 도교법 한눈에 viewer.",
+  "start_url": "./tutor/",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#f7f4ed",
+  "theme_color": "#1e40af",
+  "orientation": "portrait-primary",
+  "lang": "ko",
+  "icons": [
+    {
+      "src": "icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,60 @@
+// 출근길 법령튜터 PWA Service Worker
+// PR-H1: 기본 등록 + 푸시·알림 클릭 스켈레톤
+// PR-H4에서 알림 표시·진입 흐름 정교화 예정
+
+const SW_VERSION = 'pwa-h1-2026-05-26';
+
+self.addEventListener('install', (event) => {
+  // 정적 자료는 페이지 자체 캐시버스팅(?v=빌드시각) 사용 — SW는 즉시 활성화
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  // 이전 SW가 있다면 즉시 교체
+  event.waitUntil(self.clients.claim());
+});
+
+// 푸시 수신 (PR-H3 GitHub Actions에서 web-push로 발송)
+// 발송 페이로드 예시:
+//   { "title": "🚗 출근길 법령튜터 — 오늘의 5장",
+//     "body":  "🟦월 음주운전 · 🟦화 음주판례 · 🟦수 무면허 · 🟩목 양벌 · 🟪금 화물종사자격",
+//     "url":   "./tutor/?date=2026-05-26" }
+self.addEventListener('push', (event) => {
+  let payload = { title: '출근길 법령튜터', body: '오늘의 카드가 도착했어요.', url: './tutor/' };
+  if (event.data) {
+    try {
+      payload = Object.assign(payload, event.data.json());
+    } catch (e) {
+      // payload가 JSON이 아니면 텍스트로
+      payload.body = event.data.text() || payload.body;
+    }
+  }
+  const opts = {
+    body: payload.body,
+    icon: './icons/icon-192.svg',
+    badge: './icons/icon-192.svg',
+    data: { url: payload.url || './tutor/' },
+    tag: 'daily-tutor',
+    renotify: true,
+  };
+  event.waitUntil(self.registration.showNotification(payload.title, opts));
+});
+
+// 알림 클릭 — 튜터 페이지로 진입 (이미 열려 있으면 focus)
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = (event.notification.data && event.notification.data.url) || './tutor/';
+  event.waitUntil((async () => {
+    const all = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    for (const c of all) {
+      if (c.url.includes('/tutor/') && 'focus' in c) {
+        await c.focus();
+        if (c.navigate) await c.navigate(targetUrl);
+        return;
+      }
+    }
+    if (self.clients.openWindow) {
+      await self.clients.openWindow(targetUrl);
+    }
+  })());
+});

--- a/tutor/index.html
+++ b/tutor/index.html
@@ -4,6 +4,10 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>📚 출근길 법령 튜터 — 도로교통법 한눈에</title>
+<!-- PWA PR-H1 — manifest + theme color -->
+<link rel="manifest" href="../manifest.json">
+<meta name="theme-color" content="#1e40af">
+<link rel="apple-touch-icon" href="../icons/icon-192.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 <style>
@@ -656,6 +660,15 @@ function init() {
   render(date);
 }
 init();
+
+// PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2에서)
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('../service-worker.js', { scope: '../' })
+      .then(reg => console.log('SW 등록 OK:', reg.scope))
+      .catch(err => console.warn('SW 등록 실패:', err));
+  });
+}
 </script>
 </body>
 </html>

--- a/viewer.html
+++ b/viewer.html
@@ -7,6 +7,10 @@
 <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 <meta http-equiv="Pragma" content="no-cache">
 <meta http-equiv="Expires" content="0">
+<!-- PWA PR-H1 — manifest + theme color -->
+<link rel="manifest" href="manifest.json">
+<meta name="theme-color" content="#1e40af">
+<link rel="apple-touch-icon" href="icons/icon-192.svg">
 <title>도로교통법 한눈에 — 법률·시행령·시행규칙·별표 통합 비교</title>
 <style>
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700&display=swap');
@@ -321,12 +325,12 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 </div>
 
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
-<script src="web_data/data_core.js?v=20260525222326"></script>
-<script src="web_data/data_timeline.js?v=20260525222326"></script>
-<script src="web_data/data_tbl_diff_decree.js?v=20260525222326"></script>
-<script src="web_data/data_tbl_diff_rule.js?v=20260525222326"></script>
-<script src="web_data/data_tbl_pdf.js?v=20260525222326"></script>
-<script src="web_data/data_tbl_history.js?v=20260525222326"></script>
+<script src="web_data/data_core.js?v=20260526203441"></script>
+<script src="web_data/data_timeline.js?v=20260526203441"></script>
+<script src="web_data/data_tbl_diff_decree.js?v=20260526203441"></script>
+<script src="web_data/data_tbl_diff_rule.js?v=20260526203441"></script>
+<script src="web_data/data_tbl_pdf.js?v=20260526203441"></script>
+<script src="web_data/data_tbl_history.js?v=20260526203441"></script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑
 const mapData = window._DATA_CORE.mapData;
@@ -2394,6 +2398,15 @@ window.addEventListener('message',e=>{
   url.searchParams.delete('law');
   window.location.href=url.toString();
 });
+
+// PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('service-worker.js', { scope: './' })
+      .then(reg => console.log('SW 등록 OK:', reg.scope))
+      .catch(err => console.warn('SW 등록 실패:', err));
+  });
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- manifest.json + icons (192·512 SVG) + service-worker.js 신규
- viewer.html + tutor/index.html: PWA 메타 + SW 등록 스크립트
- 매일 푸시 알림 기반 진입 흐름의 기초 (PR-H1 / 4)

## Why
사용자 결정 — 매일 아침 카드 생성되면 모바일 푸시로 알림 → 튜터 페이지 → viewer 자연 연결. Web Push 사용 결정에 따라 PWA 변환부터.

## PR 분할
- **PR-H1 (이번)**: PWA 기본 인프라
- PR-H2: 알림 구독 UI
- PR-H3: GitHub Actions cron (매일 06:30 KST) + web-push 발송
- PR-H4: SW 알림 클릭 흐름 정교화

## Test plan
- [x] manifest.json·service-worker.js·아이콘 정적 파일 생성
- [x] viewer.html 재빌드 시 manifest/SW 등록 정확 박힘
- [ ] GitHub Pages 배포 후 모바일에서 "홈 화면 추가" 동작 (PR-H2 함께 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)