### PR TITLE
PR-H4-α: tutor 헤더 가독성·문구 개선

### DIFF
--- a/tutor/index.html
+++ b/tutor/index.html
@@ -219,7 +219,7 @@ footer a { color: var(--sub); text-decoration: underline; }
 <header style="display:flex;align-items:flex-start;justify-content:space-between;gap:10px;flex-wrap:wrap">
   <div style="flex:1;min-width:0">
     <h1 style="margin:0 0 4px;font-size:22px">📚 출근길 법령 튜터</h1>
-    <p style="margin:0;font-size:13px;color:var(--sub);line-height:1.5">매일 한 건 — 도로교통법 현행 + 해설 + 판례 통합 학습 — <a href="../viewer.html">전체 뷰어</a></p>
+    <p style="margin:0;font-size:13px;line-height:1.5;opacity:0.92">매일 한 건 — 도로교통법 현행 + 해설 + 판례 통합 학습 — <a href="../viewer.html">📖 도로교통법 통합 조회</a></p>
   </div>
   <!-- PR-H2 — 알림 구독 UI (헤더 우측 flex 배치, 모바일 wrap 대응) -->
   <button id="pushBtn" onclick="subscribePush()" style="flex-shrink:0;padding:8px 12px;border:1px solid var(--border);background:#fff;border-radius:8px;cursor:pointer;font-size:13px;color:var(--law);font-weight:600;white-space:nowrap">🔔 알림 받기</button>


### PR DESCRIPTION
## Summary
- "매일 한 건 — ..." 회색 글씨 → 흰색 본문(opacity 0.9) 복원 (진한 파란 헤더 배경에 대비 ↑)
- "전체 뷰어" → "📖 도로교통법 통합 조회"로 문구 변경 (튜터가 프론트 페이지라 목적지 명시)

## 변경 파일
- tutor/index.html (line 222)

## 검증 — Codex 교차검증 반영
- 인라인 `color:var(--sub)` 제거만으로 헤더 CSS의 `header p { opacity:0.9 }`가 살아나 흰색 본문 자동 적용
- 링크는 기존 `header a { color:#ffe }`로 흰색 계열 유지 (브라우저 기본 파란색 노출 없음)

## Test plan
- [ ] master 머지 후 https://evergreenedu-collab.github.io/road-traffic-law-viewer/tutor/ 접속
- [ ] "매일 한 건 —" 흰색으로 잘 보이는지 확인
- [ ] "📖 도로교통법 통합 조회" 클릭 시 viewer.html로 이동 확인
- [ ] 모바일(360px) 헤더 wrap 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)