### PR TITLE
PR-H4-γ-2: 별표 데이터 lazy load + 가드 (~85MB 첫 화면 절감)

### DIFF
--- a/generate_viewer.py
+++ b/generate_viewer.py
@@ -437,6 +437,8 @@ def main():
     # 단, road group viewer의 경우 튜터 가는 경로는 ./tutor/, 다른 그룹 viewer도 동일 위치(루트 기준)
     html = html.replace("{{ALARM_BUTTON}}", left_actions).replace("{{ALARM_MODAL}}", alarm_modal)
     html = html.replace("{{CURRENT_GROUP}}", group)
+    # PR-H4-γ-2: lazy load 인프라용 BUILD_TS, SUFFIX placeholder 치환
+    html = html.replace("{{BUILD_TS}}", build_ts).replace("{{SUFFIX}}", suffix)
 
     # 1) script src에 group suffix + 캐시버스팅
     html = _re.sub(
@@ -834,21 +836,64 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
+<!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
 <script src="web_data/data_core.js"></script>
-<script src="web_data/data_tbl_diff_decree.js"></script>
-<script src="web_data/data_tbl_diff_rule.js"></script>
-<script src="web_data/data_tbl_pdf.js"></script>
-<script src="web_data/data_tbl_history.js"></script>
 <script>
-// 분리 로드된 데이터를 기존 변수명에 매핑
+// 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
 const artData = window._DATA_CORE.artData;
 const tableData = window._DATA_CORE.tableData;
 const cascadeData = window._DATA_CORE.cascadeData;
 const diffData = window._DATA_CORE.diffData;
-const tblDiffData = {시행령: window._DATA_TBL_DIFF_DECREE, 시행규칙: window._DATA_TBL_DIFF_RULE};
-const tblPdfData = window._DATA_TBL_PDF;
-const tblHistoryData = window._DATA_TBL_HISTORY || {시행령:{}, 시행규칙:{}};
+// PR-H4-γ-2: 별표 자료는 빈 객체로 초기화 — lazy load 후 ensureTableExtras()에서 교체
+let tblDiffData = {시행령:{}, 시행규칙:{}};
+let tblPdfData = {};
+let tblHistoryData = {시행령:{}, 시행규칙:{}};
+const _lazyTable = { status: 'idle', promise: null };
+const _LAZY_TS = '{{BUILD_TS}}';
+const _LAZY_SFX = '{{SUFFIX}}';
+function _loadScriptOnce(src){
+  return new Promise(function(resolve, reject){
+    var s = document.createElement('script');
+    s.src = src; s.async = true;
+    s.onload = function(){ resolve(); };
+    s.onerror = function(){ reject(new Error('load failed: '+src)); };
+    document.head.appendChild(s);
+  });
+}
+function ensureTableExtras(){
+  if (_lazyTable.status === 'ready') return Promise.resolve();
+  if (_lazyTable.promise) return _lazyTable.promise;
+  _lazyTable.status = 'loading';
+  _lazyTable.promise = Promise.all([
+    _loadScriptOnce('web_data/data_tbl_diff_decree'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_diff_rule'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_pdf'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_history'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+  ]).then(function(){
+    tblDiffData = {시행령: window._DATA_TBL_DIFF_DECREE || {}, 시행규칙: window._DATA_TBL_DIFF_RULE || {}};
+    tblPdfData = window._DATA_TBL_PDF || {};
+    tblHistoryData = window._DATA_TBL_HISTORY || {시행령:{}, 시행규칙:{}};
+    _lazyTable.status = 'ready';
+  }).catch(function(e){
+    _lazyTable.status = 'error';
+    _lazyTable.promise = null;   // 재시도 허용
+    console.warn('별표 자료 lazy load 실패:', e);
+    throw e;
+  });
+  return _lazyTable.promise;
+}
+// 본문 렌더링 후 1.5초 idle 시점에 백그라운드 prefetch — 사용자가 별표 클릭하기 전에 보통 완료
+function _kickPrefetchTableExtras(){
+  setTimeout(function(){
+    if (_lazyTable.status === 'idle') ensureTableExtras().catch(function(){});
+  }, 1500);
+}
+if (document.readyState === 'complete' || document.readyState === 'interactive') {
+  _kickPrefetchTableExtras();
+} else {
+  window.addEventListener('DOMContentLoaded', _kickPrefetchTableExtras);
+}
 
 let opts=[];
 // Phase 3: 현재 viewer가 어느 법령 그룹인지 (road 외 그룹은 안내 메시지로 법령정보센터 유도)
@@ -1732,6 +1777,23 @@ function togFull(id,lawType,joKey,hang){
 }
 
 function openTable(lawType,ref){
+  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 모달 스피너 후 데이터 도착 시 재호출
+  if (_lazyTable.status !== 'ready') {
+    const overlay=document.getElementById('modalOverlay');
+    const titleEl=document.getElementById('modalTitle');
+    const bodyEl=document.getElementById('modalBody');
+    if (overlay && titleEl && bodyEl) {
+      overlay.style.display='flex';
+      titleEl.textContent=`${lawType} ${ref}`;
+      if (_lazyTable.status === 'error') {
+        bodyEl.innerHTML='<div style="text-align:center;padding:40px;color:#c0392b;font-size:14px">별표 자료를 불러오지 못했습니다.<br><br><button onclick="openTable(\''+lawType+'\',\''+ref+'\')" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div>';
+      } else {
+        bodyEl.innerHTML='<div style="text-align:center;padding:60px 20px;color:var(--sub);font-size:14px"><div style="font-size:24px;margin-bottom:12px">⏳</div>별표 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 클릭 시에만 다운로드)</span></div>';
+      }
+    }
+    ensureTableExtras().then(function(){ openTable(lawType, ref); }).catch(function(){});
+    return;
+  }
   // ref: "별표 16", "별지 제39호서식" 등
   const tables=tableData[lawType]||{};
   // 번호 추출: "별지 제39호서식" → "39", "별표 16의2" → "16의2"
@@ -1947,6 +2009,19 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
+  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 historyContent 스피너 후 도착 시 재호출
+  if (_lazyTable.status !== 'ready') {
+    const hc = document.getElementById('historyContent');
+    if (hc) {
+      if (_lazyTable.status === 'error') {
+        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
+      } else {
+        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:60px 20px;color:var(--sub)"><div style="font-size:24px;margin-bottom:12px">⏳</div>연혁 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 진입 시에만 다운로드)</span></div></div>';
+      }
+    }
+    ensureTableExtras().then(function(){ renderHistory(); }).catch(function(){});
+    return;
+  }
   // Phase 3 S3-1-b-4-b: 시행령·시행규칙 직접 진입 시 단순 diff 연혁
   if(currentLawType!=='법률'){
     renderSubLawHistory(currentLawType);

--- a/viewer.html
+++ b/viewer.html
@@ -357,21 +357,64 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
-<script src="web_data/data_core.js?v=20260527000921"></script>
-<script src="web_data/data_tbl_diff_decree.js?v=20260527000921"></script>
-<script src="web_data/data_tbl_diff_rule.js?v=20260527000921"></script>
-<script src="web_data/data_tbl_pdf.js?v=20260527000921"></script>
-<script src="web_data/data_tbl_history.js?v=20260527000921"></script>
+<!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
+<script src="web_data/data_core.js?v=20260527001418"></script>
 <script>
-// 분리 로드된 데이터를 기존 변수명에 매핑
+// 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
 const artData = window._DATA_CORE.artData;
 const tableData = window._DATA_CORE.tableData;
 const cascadeData = window._DATA_CORE.cascadeData;
 const diffData = window._DATA_CORE.diffData;
-const tblDiffData = {시행령: window._DATA_TBL_DIFF_DECREE, 시행규칙: window._DATA_TBL_DIFF_RULE};
-const tblPdfData = window._DATA_TBL_PDF;
-const tblHistoryData = window._DATA_TBL_HISTORY || {시행령:{}, 시행규칙:{}};
+// PR-H4-γ-2: 별표 자료는 빈 객체로 초기화 — lazy load 후 ensureTableExtras()에서 교체
+let tblDiffData = {시행령:{}, 시행규칙:{}};
+let tblPdfData = {};
+let tblHistoryData = {시행령:{}, 시행규칙:{}};
+const _lazyTable = { status: 'idle', promise: null };
+const _LAZY_TS = '20260527001418';
+const _LAZY_SFX = '';
+function _loadScriptOnce(src){
+  return new Promise(function(resolve, reject){
+    var s = document.createElement('script');
+    s.src = src; s.async = true;
+    s.onload = function(){ resolve(); };
+    s.onerror = function(){ reject(new Error('load failed: '+src)); };
+    document.head.appendChild(s);
+  });
+}
+function ensureTableExtras(){
+  if (_lazyTable.status === 'ready') return Promise.resolve();
+  if (_lazyTable.promise) return _lazyTable.promise;
+  _lazyTable.status = 'loading';
+  _lazyTable.promise = Promise.all([
+    _loadScriptOnce('web_data/data_tbl_diff_decree'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_diff_rule'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_pdf'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_history'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+  ]).then(function(){
+    tblDiffData = {시행령: window._DATA_TBL_DIFF_DECREE || {}, 시행규칙: window._DATA_TBL_DIFF_RULE || {}};
+    tblPdfData = window._DATA_TBL_PDF || {};
+    tblHistoryData = window._DATA_TBL_HISTORY || {시행령:{}, 시행규칙:{}};
+    _lazyTable.status = 'ready';
+  }).catch(function(e){
+    _lazyTable.status = 'error';
+    _lazyTable.promise = null;   // 재시도 허용
+    console.warn('별표 자료 lazy load 실패:', e);
+    throw e;
+  });
+  return _lazyTable.promise;
+}
+// 본문 렌더링 후 1.5초 idle 시점에 백그라운드 prefetch — 사용자가 별표 클릭하기 전에 보통 완료
+function _kickPrefetchTableExtras(){
+  setTimeout(function(){
+    if (_lazyTable.status === 'idle') ensureTableExtras().catch(function(){});
+  }, 1500);
+}
+if (document.readyState === 'complete' || document.readyState === 'interactive') {
+  _kickPrefetchTableExtras();
+} else {
+  window.addEventListener('DOMContentLoaded', _kickPrefetchTableExtras);
+}
 
 let opts=[];
 // Phase 3: 현재 viewer가 어느 법령 그룹인지 (road 외 그룹은 안내 메시지로 법령정보센터 유도)
@@ -1255,6 +1298,23 @@ function togFull(id,lawType,joKey,hang){
 }
 
 function openTable(lawType,ref){
+  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 모달 스피너 후 데이터 도착 시 재호출
+  if (_lazyTable.status !== 'ready') {
+    const overlay=document.getElementById('modalOverlay');
+    const titleEl=document.getElementById('modalTitle');
+    const bodyEl=document.getElementById('modalBody');
+    if (overlay && titleEl && bodyEl) {
+      overlay.style.display='flex';
+      titleEl.textContent=`${lawType} ${ref}`;
+      if (_lazyTable.status === 'error') {
+        bodyEl.innerHTML='<div style="text-align:center;padding:40px;color:#c0392b;font-size:14px">별표 자료를 불러오지 못했습니다.<br><br><button onclick="openTable(\''+lawType+'\',\''+ref+'\')" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div>';
+      } else {
+        bodyEl.innerHTML='<div style="text-align:center;padding:60px 20px;color:var(--sub);font-size:14px"><div style="font-size:24px;margin-bottom:12px">⏳</div>별표 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 클릭 시에만 다운로드)</span></div>';
+      }
+    }
+    ensureTableExtras().then(function(){ openTable(lawType, ref); }).catch(function(){});
+    return;
+  }
   // ref: "별표 16", "별지 제39호서식" 등
   const tables=tableData[lawType]||{};
   // 번호 추출: "별지 제39호서식" → "39", "별표 16의2" → "16의2"
@@ -1470,6 +1530,19 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
+  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 historyContent 스피너 후 도착 시 재호출
+  if (_lazyTable.status !== 'ready') {
+    const hc = document.getElementById('historyContent');
+    if (hc) {
+      if (_lazyTable.status === 'error') {
+        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
+      } else {
+        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:60px 20px;color:var(--sub)"><div style="font-size:24px;margin-bottom:12px">⏳</div>연혁 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 진입 시에만 다운로드)</span></div></div>';
+      }
+    }
+    ensureTableExtras().then(function(){ renderHistory(); }).catch(function(){});
+    return;
+  }
   // Phase 3 S3-1-b-4-b: 시행령·시행규칙 직접 진입 시 단순 diff 연혁
   if(currentLawType!=='법률'){
     renderSubLawHistory(currentLawType);

--- a/viewer_car_mgmt.html
+++ b/viewer_car_mgmt.html
@@ -356,21 +356,64 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
-<script src="web_data/data_core_car_mgmt.js?v=20260527000925"></script>
-<script src="web_data/data_tbl_diff_decree_car_mgmt.js?v=20260527000925"></script>
-<script src="web_data/data_tbl_diff_rule_car_mgmt.js?v=20260527000925"></script>
-<script src="web_data/data_tbl_pdf_car_mgmt.js?v=20260527000925"></script>
-<script src="web_data/data_tbl_history_car_mgmt.js?v=20260527000925"></script>
+<!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
+<script src="web_data/data_core_car_mgmt.js?v=20260527001422"></script>
 <script>
-// 분리 로드된 데이터를 기존 변수명에 매핑
+// 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
 const artData = window._DATA_CORE.artData;
 const tableData = window._DATA_CORE.tableData;
 const cascadeData = window._DATA_CORE.cascadeData;
 const diffData = window._DATA_CORE.diffData;
-const tblDiffData = {시행령: window._DATA_TBL_DIFF_DECREE, 시행규칙: window._DATA_TBL_DIFF_RULE};
-const tblPdfData = window._DATA_TBL_PDF;
-const tblHistoryData = window._DATA_TBL_HISTORY || {시행령:{}, 시행규칙:{}};
+// PR-H4-γ-2: 별표 자료는 빈 객체로 초기화 — lazy load 후 ensureTableExtras()에서 교체
+let tblDiffData = {시행령:{}, 시행규칙:{}};
+let tblPdfData = {};
+let tblHistoryData = {시행령:{}, 시행규칙:{}};
+const _lazyTable = { status: 'idle', promise: null };
+const _LAZY_TS = '20260527001422';
+const _LAZY_SFX = '_car_mgmt';
+function _loadScriptOnce(src){
+  return new Promise(function(resolve, reject){
+    var s = document.createElement('script');
+    s.src = src; s.async = true;
+    s.onload = function(){ resolve(); };
+    s.onerror = function(){ reject(new Error('load failed: '+src)); };
+    document.head.appendChild(s);
+  });
+}
+function ensureTableExtras(){
+  if (_lazyTable.status === 'ready') return Promise.resolve();
+  if (_lazyTable.promise) return _lazyTable.promise;
+  _lazyTable.status = 'loading';
+  _lazyTable.promise = Promise.all([
+    _loadScriptOnce('web_data/data_tbl_diff_decree'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_diff_rule'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_pdf'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_history'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+  ]).then(function(){
+    tblDiffData = {시행령: window._DATA_TBL_DIFF_DECREE || {}, 시행규칙: window._DATA_TBL_DIFF_RULE || {}};
+    tblPdfData = window._DATA_TBL_PDF || {};
+    tblHistoryData = window._DATA_TBL_HISTORY || {시행령:{}, 시행규칙:{}};
+    _lazyTable.status = 'ready';
+  }).catch(function(e){
+    _lazyTable.status = 'error';
+    _lazyTable.promise = null;   // 재시도 허용
+    console.warn('별표 자료 lazy load 실패:', e);
+    throw e;
+  });
+  return _lazyTable.promise;
+}
+// 본문 렌더링 후 1.5초 idle 시점에 백그라운드 prefetch — 사용자가 별표 클릭하기 전에 보통 완료
+function _kickPrefetchTableExtras(){
+  setTimeout(function(){
+    if (_lazyTable.status === 'idle') ensureTableExtras().catch(function(){});
+  }, 1500);
+}
+if (document.readyState === 'complete' || document.readyState === 'interactive') {
+  _kickPrefetchTableExtras();
+} else {
+  window.addEventListener('DOMContentLoaded', _kickPrefetchTableExtras);
+}
 
 let opts=[];
 // Phase 3: 현재 viewer가 어느 법령 그룹인지 (road 외 그룹은 안내 메시지로 법령정보센터 유도)
@@ -1254,6 +1297,23 @@ function togFull(id,lawType,joKey,hang){
 }
 
 function openTable(lawType,ref){
+  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 모달 스피너 후 데이터 도착 시 재호출
+  if (_lazyTable.status !== 'ready') {
+    const overlay=document.getElementById('modalOverlay');
+    const titleEl=document.getElementById('modalTitle');
+    const bodyEl=document.getElementById('modalBody');
+    if (overlay && titleEl && bodyEl) {
+      overlay.style.display='flex';
+      titleEl.textContent=`${lawType} ${ref}`;
+      if (_lazyTable.status === 'error') {
+        bodyEl.innerHTML='<div style="text-align:center;padding:40px;color:#c0392b;font-size:14px">별표 자료를 불러오지 못했습니다.<br><br><button onclick="openTable(\''+lawType+'\',\''+ref+'\')" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div>';
+      } else {
+        bodyEl.innerHTML='<div style="text-align:center;padding:60px 20px;color:var(--sub);font-size:14px"><div style="font-size:24px;margin-bottom:12px">⏳</div>별표 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 클릭 시에만 다운로드)</span></div>';
+      }
+    }
+    ensureTableExtras().then(function(){ openTable(lawType, ref); }).catch(function(){});
+    return;
+  }
   // ref: "별표 16", "별지 제39호서식" 등
   const tables=tableData[lawType]||{};
   // 번호 추출: "별지 제39호서식" → "39", "별표 16의2" → "16의2"
@@ -1469,6 +1529,19 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
+  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 historyContent 스피너 후 도착 시 재호출
+  if (_lazyTable.status !== 'ready') {
+    const hc = document.getElementById('historyContent');
+    if (hc) {
+      if (_lazyTable.status === 'error') {
+        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
+      } else {
+        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:60px 20px;color:var(--sub)"><div style="font-size:24px;margin-bottom:12px">⏳</div>연혁 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 진입 시에만 다운로드)</span></div></div>';
+      }
+    }
+    ensureTableExtras().then(function(){ renderHistory(); }).catch(function(){});
+    return;
+  }
   // Phase 3 S3-1-b-4-b: 시행령·시행규칙 직접 진입 시 단순 diff 연혁
   if(currentLawType!=='법률'){
     renderSubLawHistory(currentLawType);

--- a/viewer_cargo_transport.html
+++ b/viewer_cargo_transport.html
@@ -356,21 +356,64 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
-<script src="web_data/data_core_cargo_transport.js?v=20260527000928"></script>
-<script src="web_data/data_tbl_diff_decree_cargo_transport.js?v=20260527000928"></script>
-<script src="web_data/data_tbl_diff_rule_cargo_transport.js?v=20260527000928"></script>
-<script src="web_data/data_tbl_pdf_cargo_transport.js?v=20260527000928"></script>
-<script src="web_data/data_tbl_history_cargo_transport.js?v=20260527000928"></script>
+<!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
+<script src="web_data/data_core_cargo_transport.js?v=20260527001425"></script>
 <script>
-// 분리 로드된 데이터를 기존 변수명에 매핑
+// 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
 const artData = window._DATA_CORE.artData;
 const tableData = window._DATA_CORE.tableData;
 const cascadeData = window._DATA_CORE.cascadeData;
 const diffData = window._DATA_CORE.diffData;
-const tblDiffData = {시행령: window._DATA_TBL_DIFF_DECREE, 시행규칙: window._DATA_TBL_DIFF_RULE};
-const tblPdfData = window._DATA_TBL_PDF;
-const tblHistoryData = window._DATA_TBL_HISTORY || {시행령:{}, 시행규칙:{}};
+// PR-H4-γ-2: 별표 자료는 빈 객체로 초기화 — lazy load 후 ensureTableExtras()에서 교체
+let tblDiffData = {시행령:{}, 시행규칙:{}};
+let tblPdfData = {};
+let tblHistoryData = {시행령:{}, 시행규칙:{}};
+const _lazyTable = { status: 'idle', promise: null };
+const _LAZY_TS = '20260527001425';
+const _LAZY_SFX = '_cargo_transport';
+function _loadScriptOnce(src){
+  return new Promise(function(resolve, reject){
+    var s = document.createElement('script');
+    s.src = src; s.async = true;
+    s.onload = function(){ resolve(); };
+    s.onerror = function(){ reject(new Error('load failed: '+src)); };
+    document.head.appendChild(s);
+  });
+}
+function ensureTableExtras(){
+  if (_lazyTable.status === 'ready') return Promise.resolve();
+  if (_lazyTable.promise) return _lazyTable.promise;
+  _lazyTable.status = 'loading';
+  _lazyTable.promise = Promise.all([
+    _loadScriptOnce('web_data/data_tbl_diff_decree'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_diff_rule'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_pdf'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_history'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+  ]).then(function(){
+    tblDiffData = {시행령: window._DATA_TBL_DIFF_DECREE || {}, 시행규칙: window._DATA_TBL_DIFF_RULE || {}};
+    tblPdfData = window._DATA_TBL_PDF || {};
+    tblHistoryData = window._DATA_TBL_HISTORY || {시행령:{}, 시행규칙:{}};
+    _lazyTable.status = 'ready';
+  }).catch(function(e){
+    _lazyTable.status = 'error';
+    _lazyTable.promise = null;   // 재시도 허용
+    console.warn('별표 자료 lazy load 실패:', e);
+    throw e;
+  });
+  return _lazyTable.promise;
+}
+// 본문 렌더링 후 1.5초 idle 시점에 백그라운드 prefetch — 사용자가 별표 클릭하기 전에 보통 완료
+function _kickPrefetchTableExtras(){
+  setTimeout(function(){
+    if (_lazyTable.status === 'idle') ensureTableExtras().catch(function(){});
+  }, 1500);
+}
+if (document.readyState === 'complete' || document.readyState === 'interactive') {
+  _kickPrefetchTableExtras();
+} else {
+  window.addEventListener('DOMContentLoaded', _kickPrefetchTableExtras);
+}
 
 let opts=[];
 // Phase 3: 현재 viewer가 어느 법령 그룹인지 (road 외 그룹은 안내 메시지로 법령정보센터 유도)
@@ -1254,6 +1297,23 @@ function togFull(id,lawType,joKey,hang){
 }
 
 function openTable(lawType,ref){
+  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 모달 스피너 후 데이터 도착 시 재호출
+  if (_lazyTable.status !== 'ready') {
+    const overlay=document.getElementById('modalOverlay');
+    const titleEl=document.getElementById('modalTitle');
+    const bodyEl=document.getElementById('modalBody');
+    if (overlay && titleEl && bodyEl) {
+      overlay.style.display='flex';
+      titleEl.textContent=`${lawType} ${ref}`;
+      if (_lazyTable.status === 'error') {
+        bodyEl.innerHTML='<div style="text-align:center;padding:40px;color:#c0392b;font-size:14px">별표 자료를 불러오지 못했습니다.<br><br><button onclick="openTable(\''+lawType+'\',\''+ref+'\')" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div>';
+      } else {
+        bodyEl.innerHTML='<div style="text-align:center;padding:60px 20px;color:var(--sub);font-size:14px"><div style="font-size:24px;margin-bottom:12px">⏳</div>별표 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 클릭 시에만 다운로드)</span></div>';
+      }
+    }
+    ensureTableExtras().then(function(){ openTable(lawType, ref); }).catch(function(){});
+    return;
+  }
   // ref: "별표 16", "별지 제39호서식" 등
   const tables=tableData[lawType]||{};
   // 번호 추출: "별지 제39호서식" → "39", "별표 16의2" → "16의2"
@@ -1469,6 +1529,19 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
+  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 historyContent 스피너 후 도착 시 재호출
+  if (_lazyTable.status !== 'ready') {
+    const hc = document.getElementById('historyContent');
+    if (hc) {
+      if (_lazyTable.status === 'error') {
+        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
+      } else {
+        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:60px 20px;color:var(--sub)"><div style="font-size:24px;margin-bottom:12px">⏳</div>연혁 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 진입 시에만 다운로드)</span></div></div>';
+      }
+    }
+    ensureTableExtras().then(function(){ renderHistory(); }).catch(function(){});
+    return;
+  }
   // Phase 3 S3-1-b-4-b: 시행령·시행규칙 직접 진입 시 단순 diff 연혁
   if(currentLawType!=='법률'){
     renderSubLawHistory(currentLawType);

--- a/viewer_crim_proc.html
+++ b/viewer_crim_proc.html
@@ -356,21 +356,64 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
-<script src="web_data/data_core_crim_proc.js?v=20260527000929"></script>
-<script src="web_data/data_tbl_diff_decree_crim_proc.js?v=20260527000929"></script>
-<script src="web_data/data_tbl_diff_rule_crim_proc.js?v=20260527000929"></script>
-<script src="web_data/data_tbl_pdf_crim_proc.js?v=20260527000929"></script>
-<script src="web_data/data_tbl_history_crim_proc.js?v=20260527000929"></script>
+<!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
+<script src="web_data/data_core_crim_proc.js?v=20260527001425"></script>
 <script>
-// 분리 로드된 데이터를 기존 변수명에 매핑
+// 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
 const artData = window._DATA_CORE.artData;
 const tableData = window._DATA_CORE.tableData;
 const cascadeData = window._DATA_CORE.cascadeData;
 const diffData = window._DATA_CORE.diffData;
-const tblDiffData = {시행령: window._DATA_TBL_DIFF_DECREE, 시행규칙: window._DATA_TBL_DIFF_RULE};
-const tblPdfData = window._DATA_TBL_PDF;
-const tblHistoryData = window._DATA_TBL_HISTORY || {시행령:{}, 시행규칙:{}};
+// PR-H4-γ-2: 별표 자료는 빈 객체로 초기화 — lazy load 후 ensureTableExtras()에서 교체
+let tblDiffData = {시행령:{}, 시행규칙:{}};
+let tblPdfData = {};
+let tblHistoryData = {시행령:{}, 시행규칙:{}};
+const _lazyTable = { status: 'idle', promise: null };
+const _LAZY_TS = '20260527001425';
+const _LAZY_SFX = '_crim_proc';
+function _loadScriptOnce(src){
+  return new Promise(function(resolve, reject){
+    var s = document.createElement('script');
+    s.src = src; s.async = true;
+    s.onload = function(){ resolve(); };
+    s.onerror = function(){ reject(new Error('load failed: '+src)); };
+    document.head.appendChild(s);
+  });
+}
+function ensureTableExtras(){
+  if (_lazyTable.status === 'ready') return Promise.resolve();
+  if (_lazyTable.promise) return _lazyTable.promise;
+  _lazyTable.status = 'loading';
+  _lazyTable.promise = Promise.all([
+    _loadScriptOnce('web_data/data_tbl_diff_decree'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_diff_rule'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_pdf'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_history'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+  ]).then(function(){
+    tblDiffData = {시행령: window._DATA_TBL_DIFF_DECREE || {}, 시행규칙: window._DATA_TBL_DIFF_RULE || {}};
+    tblPdfData = window._DATA_TBL_PDF || {};
+    tblHistoryData = window._DATA_TBL_HISTORY || {시행령:{}, 시행규칙:{}};
+    _lazyTable.status = 'ready';
+  }).catch(function(e){
+    _lazyTable.status = 'error';
+    _lazyTable.promise = null;   // 재시도 허용
+    console.warn('별표 자료 lazy load 실패:', e);
+    throw e;
+  });
+  return _lazyTable.promise;
+}
+// 본문 렌더링 후 1.5초 idle 시점에 백그라운드 prefetch — 사용자가 별표 클릭하기 전에 보통 완료
+function _kickPrefetchTableExtras(){
+  setTimeout(function(){
+    if (_lazyTable.status === 'idle') ensureTableExtras().catch(function(){});
+  }, 1500);
+}
+if (document.readyState === 'complete' || document.readyState === 'interactive') {
+  _kickPrefetchTableExtras();
+} else {
+  window.addEventListener('DOMContentLoaded', _kickPrefetchTableExtras);
+}
 
 let opts=[];
 // Phase 3: 현재 viewer가 어느 법령 그룹인지 (road 외 그룹은 안내 메시지로 법령정보센터 유도)
@@ -1254,6 +1297,23 @@ function togFull(id,lawType,joKey,hang){
 }
 
 function openTable(lawType,ref){
+  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 모달 스피너 후 데이터 도착 시 재호출
+  if (_lazyTable.status !== 'ready') {
+    const overlay=document.getElementById('modalOverlay');
+    const titleEl=document.getElementById('modalTitle');
+    const bodyEl=document.getElementById('modalBody');
+    if (overlay && titleEl && bodyEl) {
+      overlay.style.display='flex';
+      titleEl.textContent=`${lawType} ${ref}`;
+      if (_lazyTable.status === 'error') {
+        bodyEl.innerHTML='<div style="text-align:center;padding:40px;color:#c0392b;font-size:14px">별표 자료를 불러오지 못했습니다.<br><br><button onclick="openTable(\''+lawType+'\',\''+ref+'\')" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div>';
+      } else {
+        bodyEl.innerHTML='<div style="text-align:center;padding:60px 20px;color:var(--sub);font-size:14px"><div style="font-size:24px;margin-bottom:12px">⏳</div>별표 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 클릭 시에만 다운로드)</span></div>';
+      }
+    }
+    ensureTableExtras().then(function(){ openTable(lawType, ref); }).catch(function(){});
+    return;
+  }
   // ref: "별표 16", "별지 제39호서식" 등
   const tables=tableData[lawType]||{};
   // 번호 추출: "별지 제39호서식" → "39", "별표 16의2" → "16의2"
@@ -1469,6 +1529,19 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
+  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 historyContent 스피너 후 도착 시 재호출
+  if (_lazyTable.status !== 'ready') {
+    const hc = document.getElementById('historyContent');
+    if (hc) {
+      if (_lazyTable.status === 'error') {
+        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
+      } else {
+        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:60px 20px;color:var(--sub)"><div style="font-size:24px;margin-bottom:12px">⏳</div>연혁 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 진입 시에만 다운로드)</span></div></div>';
+      }
+    }
+    ensureTableExtras().then(function(){ renderHistory(); }).catch(function(){});
+    return;
+  }
   // Phase 3 S3-1-b-4-b: 시행령·시행규칙 직접 진입 시 단순 diff 연혁
   if(currentLawType!=='법률'){
     renderSubLawHistory(currentLawType);

--- a/viewer_passenger_transport.html
+++ b/viewer_passenger_transport.html
@@ -356,21 +356,64 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
-<script src="web_data/data_core_passenger_transport.js?v=20260527000927"></script>
-<script src="web_data/data_tbl_diff_decree_passenger_transport.js?v=20260527000927"></script>
-<script src="web_data/data_tbl_diff_rule_passenger_transport.js?v=20260527000927"></script>
-<script src="web_data/data_tbl_pdf_passenger_transport.js?v=20260527000927"></script>
-<script src="web_data/data_tbl_history_passenger_transport.js?v=20260527000927"></script>
+<!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
+<script src="web_data/data_core_passenger_transport.js?v=20260527001424"></script>
 <script>
-// 분리 로드된 데이터를 기존 변수명에 매핑
+// 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
 const artData = window._DATA_CORE.artData;
 const tableData = window._DATA_CORE.tableData;
 const cascadeData = window._DATA_CORE.cascadeData;
 const diffData = window._DATA_CORE.diffData;
-const tblDiffData = {시행령: window._DATA_TBL_DIFF_DECREE, 시행규칙: window._DATA_TBL_DIFF_RULE};
-const tblPdfData = window._DATA_TBL_PDF;
-const tblHistoryData = window._DATA_TBL_HISTORY || {시행령:{}, 시행규칙:{}};
+// PR-H4-γ-2: 별표 자료는 빈 객체로 초기화 — lazy load 후 ensureTableExtras()에서 교체
+let tblDiffData = {시행령:{}, 시행규칙:{}};
+let tblPdfData = {};
+let tblHistoryData = {시행령:{}, 시행규칙:{}};
+const _lazyTable = { status: 'idle', promise: null };
+const _LAZY_TS = '20260527001424';
+const _LAZY_SFX = '_passenger_transport';
+function _loadScriptOnce(src){
+  return new Promise(function(resolve, reject){
+    var s = document.createElement('script');
+    s.src = src; s.async = true;
+    s.onload = function(){ resolve(); };
+    s.onerror = function(){ reject(new Error('load failed: '+src)); };
+    document.head.appendChild(s);
+  });
+}
+function ensureTableExtras(){
+  if (_lazyTable.status === 'ready') return Promise.resolve();
+  if (_lazyTable.promise) return _lazyTable.promise;
+  _lazyTable.status = 'loading';
+  _lazyTable.promise = Promise.all([
+    _loadScriptOnce('web_data/data_tbl_diff_decree'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_diff_rule'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_pdf'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_history'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+  ]).then(function(){
+    tblDiffData = {시행령: window._DATA_TBL_DIFF_DECREE || {}, 시행규칙: window._DATA_TBL_DIFF_RULE || {}};
+    tblPdfData = window._DATA_TBL_PDF || {};
+    tblHistoryData = window._DATA_TBL_HISTORY || {시행령:{}, 시행규칙:{}};
+    _lazyTable.status = 'ready';
+  }).catch(function(e){
+    _lazyTable.status = 'error';
+    _lazyTable.promise = null;   // 재시도 허용
+    console.warn('별표 자료 lazy load 실패:', e);
+    throw e;
+  });
+  return _lazyTable.promise;
+}
+// 본문 렌더링 후 1.5초 idle 시점에 백그라운드 prefetch — 사용자가 별표 클릭하기 전에 보통 완료
+function _kickPrefetchTableExtras(){
+  setTimeout(function(){
+    if (_lazyTable.status === 'idle') ensureTableExtras().catch(function(){});
+  }, 1500);
+}
+if (document.readyState === 'complete' || document.readyState === 'interactive') {
+  _kickPrefetchTableExtras();
+} else {
+  window.addEventListener('DOMContentLoaded', _kickPrefetchTableExtras);
+}
 
 let opts=[];
 // Phase 3: 현재 viewer가 어느 법령 그룹인지 (road 외 그룹은 안내 메시지로 법령정보센터 유도)
@@ -1254,6 +1297,23 @@ function togFull(id,lawType,joKey,hang){
 }
 
 function openTable(lawType,ref){
+  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 모달 스피너 후 데이터 도착 시 재호출
+  if (_lazyTable.status !== 'ready') {
+    const overlay=document.getElementById('modalOverlay');
+    const titleEl=document.getElementById('modalTitle');
+    const bodyEl=document.getElementById('modalBody');
+    if (overlay && titleEl && bodyEl) {
+      overlay.style.display='flex';
+      titleEl.textContent=`${lawType} ${ref}`;
+      if (_lazyTable.status === 'error') {
+        bodyEl.innerHTML='<div style="text-align:center;padding:40px;color:#c0392b;font-size:14px">별표 자료를 불러오지 못했습니다.<br><br><button onclick="openTable(\''+lawType+'\',\''+ref+'\')" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div>';
+      } else {
+        bodyEl.innerHTML='<div style="text-align:center;padding:60px 20px;color:var(--sub);font-size:14px"><div style="font-size:24px;margin-bottom:12px">⏳</div>별표 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 클릭 시에만 다운로드)</span></div>';
+      }
+    }
+    ensureTableExtras().then(function(){ openTable(lawType, ref); }).catch(function(){});
+    return;
+  }
   // ref: "별표 16", "별지 제39호서식" 등
   const tables=tableData[lawType]||{};
   // 번호 추출: "별지 제39호서식" → "39", "별표 16의2" → "16의2"
@@ -1469,6 +1529,19 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
+  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 historyContent 스피너 후 도착 시 재호출
+  if (_lazyTable.status !== 'ready') {
+    const hc = document.getElementById('historyContent');
+    if (hc) {
+      if (_lazyTable.status === 'error') {
+        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
+      } else {
+        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:60px 20px;color:var(--sub)"><div style="font-size:24px;margin-bottom:12px">⏳</div>연혁 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 진입 시에만 다운로드)</span></div></div>';
+      }
+    }
+    ensureTableExtras().then(function(){ renderHistory(); }).catch(function(){});
+    return;
+  }
   // Phase 3 S3-1-b-4-b: 시행령·시행규칙 직접 진입 시 단순 diff 연혁
   if(currentLawType!=='법률'){
     renderSubLawHistory(currentLawType);

--- a/viewer_tkga.html
+++ b/viewer_tkga.html
@@ -356,21 +356,64 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
-<script src="web_data/data_core_tkga.js?v=20260527000922"></script>
-<script src="web_data/data_tbl_diff_decree_tkga.js?v=20260527000922"></script>
-<script src="web_data/data_tbl_diff_rule_tkga.js?v=20260527000922"></script>
-<script src="web_data/data_tbl_pdf_tkga.js?v=20260527000922"></script>
-<script src="web_data/data_tbl_history_tkga.js?v=20260527000922"></script>
+<!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
+<script src="web_data/data_core_tkga.js?v=20260527001419"></script>
 <script>
-// 분리 로드된 데이터를 기존 변수명에 매핑
+// 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
 const artData = window._DATA_CORE.artData;
 const tableData = window._DATA_CORE.tableData;
 const cascadeData = window._DATA_CORE.cascadeData;
 const diffData = window._DATA_CORE.diffData;
-const tblDiffData = {시행령: window._DATA_TBL_DIFF_DECREE, 시행규칙: window._DATA_TBL_DIFF_RULE};
-const tblPdfData = window._DATA_TBL_PDF;
-const tblHistoryData = window._DATA_TBL_HISTORY || {시행령:{}, 시행규칙:{}};
+// PR-H4-γ-2: 별표 자료는 빈 객체로 초기화 — lazy load 후 ensureTableExtras()에서 교체
+let tblDiffData = {시행령:{}, 시행규칙:{}};
+let tblPdfData = {};
+let tblHistoryData = {시행령:{}, 시행규칙:{}};
+const _lazyTable = { status: 'idle', promise: null };
+const _LAZY_TS = '20260527001419';
+const _LAZY_SFX = '_tkga';
+function _loadScriptOnce(src){
+  return new Promise(function(resolve, reject){
+    var s = document.createElement('script');
+    s.src = src; s.async = true;
+    s.onload = function(){ resolve(); };
+    s.onerror = function(){ reject(new Error('load failed: '+src)); };
+    document.head.appendChild(s);
+  });
+}
+function ensureTableExtras(){
+  if (_lazyTable.status === 'ready') return Promise.resolve();
+  if (_lazyTable.promise) return _lazyTable.promise;
+  _lazyTable.status = 'loading';
+  _lazyTable.promise = Promise.all([
+    _loadScriptOnce('web_data/data_tbl_diff_decree'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_diff_rule'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_pdf'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_history'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+  ]).then(function(){
+    tblDiffData = {시행령: window._DATA_TBL_DIFF_DECREE || {}, 시행규칙: window._DATA_TBL_DIFF_RULE || {}};
+    tblPdfData = window._DATA_TBL_PDF || {};
+    tblHistoryData = window._DATA_TBL_HISTORY || {시행령:{}, 시행규칙:{}};
+    _lazyTable.status = 'ready';
+  }).catch(function(e){
+    _lazyTable.status = 'error';
+    _lazyTable.promise = null;   // 재시도 허용
+    console.warn('별표 자료 lazy load 실패:', e);
+    throw e;
+  });
+  return _lazyTable.promise;
+}
+// 본문 렌더링 후 1.5초 idle 시점에 백그라운드 prefetch — 사용자가 별표 클릭하기 전에 보통 완료
+function _kickPrefetchTableExtras(){
+  setTimeout(function(){
+    if (_lazyTable.status === 'idle') ensureTableExtras().catch(function(){});
+  }, 1500);
+}
+if (document.readyState === 'complete' || document.readyState === 'interactive') {
+  _kickPrefetchTableExtras();
+} else {
+  window.addEventListener('DOMContentLoaded', _kickPrefetchTableExtras);
+}
 
 let opts=[];
 // Phase 3: 현재 viewer가 어느 법령 그룹인지 (road 외 그룹은 안내 메시지로 법령정보센터 유도)
@@ -1254,6 +1297,23 @@ function togFull(id,lawType,joKey,hang){
 }
 
 function openTable(lawType,ref){
+  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 모달 스피너 후 데이터 도착 시 재호출
+  if (_lazyTable.status !== 'ready') {
+    const overlay=document.getElementById('modalOverlay');
+    const titleEl=document.getElementById('modalTitle');
+    const bodyEl=document.getElementById('modalBody');
+    if (overlay && titleEl && bodyEl) {
+      overlay.style.display='flex';
+      titleEl.textContent=`${lawType} ${ref}`;
+      if (_lazyTable.status === 'error') {
+        bodyEl.innerHTML='<div style="text-align:center;padding:40px;color:#c0392b;font-size:14px">별표 자료를 불러오지 못했습니다.<br><br><button onclick="openTable(\''+lawType+'\',\''+ref+'\')" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div>';
+      } else {
+        bodyEl.innerHTML='<div style="text-align:center;padding:60px 20px;color:var(--sub);font-size:14px"><div style="font-size:24px;margin-bottom:12px">⏳</div>별표 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 클릭 시에만 다운로드)</span></div>';
+      }
+    }
+    ensureTableExtras().then(function(){ openTable(lawType, ref); }).catch(function(){});
+    return;
+  }
   // ref: "별표 16", "별지 제39호서식" 등
   const tables=tableData[lawType]||{};
   // 번호 추출: "별지 제39호서식" → "39", "별표 16의2" → "16의2"
@@ -1469,6 +1529,19 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
+  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 historyContent 스피너 후 도착 시 재호출
+  if (_lazyTable.status !== 'ready') {
+    const hc = document.getElementById('historyContent');
+    if (hc) {
+      if (_lazyTable.status === 'error') {
+        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
+      } else {
+        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:60px 20px;color:var(--sub)"><div style="font-size:24px;margin-bottom:12px">⏳</div>연혁 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 진입 시에만 다운로드)</span></div></div>';
+      }
+    }
+    ensureTableExtras().then(function(){ renderHistory(); }).catch(function(){});
+    return;
+  }
   // Phase 3 S3-1-b-4-b: 시행령·시행규칙 직접 진입 시 단순 diff 연혁
   if(currentLawType!=='법률'){
     renderSubLawHistory(currentLawType);

--- a/viewer_tlspc.html
+++ b/viewer_tlspc.html
@@ -356,21 +356,64 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
-<script src="web_data/data_core_tlspc.js?v=20260527000922"></script>
-<script src="web_data/data_tbl_diff_decree_tlspc.js?v=20260527000922"></script>
-<script src="web_data/data_tbl_diff_rule_tlspc.js?v=20260527000922"></script>
-<script src="web_data/data_tbl_pdf_tlspc.js?v=20260527000922"></script>
-<script src="web_data/data_tbl_history_tlspc.js?v=20260527000922"></script>
+<!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
+<script src="web_data/data_core_tlspc.js?v=20260527001419"></script>
 <script>
-// 분리 로드된 데이터를 기존 변수명에 매핑
+// 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
 const artData = window._DATA_CORE.artData;
 const tableData = window._DATA_CORE.tableData;
 const cascadeData = window._DATA_CORE.cascadeData;
 const diffData = window._DATA_CORE.diffData;
-const tblDiffData = {시행령: window._DATA_TBL_DIFF_DECREE, 시행규칙: window._DATA_TBL_DIFF_RULE};
-const tblPdfData = window._DATA_TBL_PDF;
-const tblHistoryData = window._DATA_TBL_HISTORY || {시행령:{}, 시행규칙:{}};
+// PR-H4-γ-2: 별표 자료는 빈 객체로 초기화 — lazy load 후 ensureTableExtras()에서 교체
+let tblDiffData = {시행령:{}, 시행규칙:{}};
+let tblPdfData = {};
+let tblHistoryData = {시행령:{}, 시행규칙:{}};
+const _lazyTable = { status: 'idle', promise: null };
+const _LAZY_TS = '20260527001419';
+const _LAZY_SFX = '_tlspc';
+function _loadScriptOnce(src){
+  return new Promise(function(resolve, reject){
+    var s = document.createElement('script');
+    s.src = src; s.async = true;
+    s.onload = function(){ resolve(); };
+    s.onerror = function(){ reject(new Error('load failed: '+src)); };
+    document.head.appendChild(s);
+  });
+}
+function ensureTableExtras(){
+  if (_lazyTable.status === 'ready') return Promise.resolve();
+  if (_lazyTable.promise) return _lazyTable.promise;
+  _lazyTable.status = 'loading';
+  _lazyTable.promise = Promise.all([
+    _loadScriptOnce('web_data/data_tbl_diff_decree'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_diff_rule'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_pdf'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+    _loadScriptOnce('web_data/data_tbl_history'+_LAZY_SFX+'.js?v='+_LAZY_TS),
+  ]).then(function(){
+    tblDiffData = {시행령: window._DATA_TBL_DIFF_DECREE || {}, 시행규칙: window._DATA_TBL_DIFF_RULE || {}};
+    tblPdfData = window._DATA_TBL_PDF || {};
+    tblHistoryData = window._DATA_TBL_HISTORY || {시행령:{}, 시행규칙:{}};
+    _lazyTable.status = 'ready';
+  }).catch(function(e){
+    _lazyTable.status = 'error';
+    _lazyTable.promise = null;   // 재시도 허용
+    console.warn('별표 자료 lazy load 실패:', e);
+    throw e;
+  });
+  return _lazyTable.promise;
+}
+// 본문 렌더링 후 1.5초 idle 시점에 백그라운드 prefetch — 사용자가 별표 클릭하기 전에 보통 완료
+function _kickPrefetchTableExtras(){
+  setTimeout(function(){
+    if (_lazyTable.status === 'idle') ensureTableExtras().catch(function(){});
+  }, 1500);
+}
+if (document.readyState === 'complete' || document.readyState === 'interactive') {
+  _kickPrefetchTableExtras();
+} else {
+  window.addEventListener('DOMContentLoaded', _kickPrefetchTableExtras);
+}
 
 let opts=[];
 // Phase 3: 현재 viewer가 어느 법령 그룹인지 (road 외 그룹은 안내 메시지로 법령정보센터 유도)
@@ -1254,6 +1297,23 @@ function togFull(id,lawType,joKey,hang){
 }
 
 function openTable(lawType,ref){
+  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 모달 스피너 후 데이터 도착 시 재호출
+  if (_lazyTable.status !== 'ready') {
+    const overlay=document.getElementById('modalOverlay');
+    const titleEl=document.getElementById('modalTitle');
+    const bodyEl=document.getElementById('modalBody');
+    if (overlay && titleEl && bodyEl) {
+      overlay.style.display='flex';
+      titleEl.textContent=`${lawType} ${ref}`;
+      if (_lazyTable.status === 'error') {
+        bodyEl.innerHTML='<div style="text-align:center;padding:40px;color:#c0392b;font-size:14px">별표 자료를 불러오지 못했습니다.<br><br><button onclick="openTable(\''+lawType+'\',\''+ref+'\')" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div>';
+      } else {
+        bodyEl.innerHTML='<div style="text-align:center;padding:60px 20px;color:var(--sub);font-size:14px"><div style="font-size:24px;margin-bottom:12px">⏳</div>별표 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 클릭 시에만 다운로드)</span></div>';
+      }
+    }
+    ensureTableExtras().then(function(){ openTable(lawType, ref); }).catch(function(){});
+    return;
+  }
   // ref: "별표 16", "별지 제39호서식" 등
   const tables=tableData[lawType]||{};
   // 번호 추출: "별지 제39호서식" → "39", "별표 16의2" → "16의2"
@@ -1469,6 +1529,19 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
+  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 historyContent 스피너 후 도착 시 재호출
+  if (_lazyTable.status !== 'ready') {
+    const hc = document.getElementById('historyContent');
+    if (hc) {
+      if (_lazyTable.status === 'error') {
+        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
+      } else {
+        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:60px 20px;color:var(--sub)"><div style="font-size:24px;margin-bottom:12px">⏳</div>연혁 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 진입 시에만 다운로드)</span></div></div>';
+      }
+    }
+    ensureTableExtras().then(function(){ renderHistory(); }).catch(function(){});
+    return;
+  }
   // Phase 3 S3-1-b-4-b: 시행령·시행규칙 직접 진입 시 단순 diff 연혁
   if(currentLawType!=='법률'){
     renderSubLawHistory(currentLawType);


### PR DESCRIPTION
## Summary
도교법 viewer 첫 화면 동기 로드 **132MB → 35MB (-85MB)**, gzip 압축 후 ~5MB.

## 변경 내용
- **lazy load 대상** (별표·연혁 탭 진입 시점에만 필요):
  - `data_tbl_diff_rule.js` (71MB, 시행규칙 별표 전후비교)
  - `data_tbl_diff_decree.js` (7MB, 시행령 별표 전후비교)
  - `data_tbl_pdf.js` (별표 PDF 매핑)
  - `data_tbl_history.js` (4MB, 별표 연혁)
- **동기 유지**: `data_core.js` (35MB) — 본문 즉시 렌더링 위해 필수

## 설계 (Codex 교차검증 권고 반영)
- 동적 `<script>` 삽입 (window._DATA_TBL_* 전역 할당 패턴 유지) — `fetch+eval` 회피
- 빈 객체로 초기화 → 가드 실패해도 `undefined[lawType]` 폭발 없음
- `_lazyTable.status` 상태머신 (idle/loading/ready/error)
- `_lazyTable.promise` 중복 호출 시 같은 Promise 재사용 (race 안전)
- **진입점 가드** 2곳 — Codex가 짚은 정확한 위치:
  - `openTable()`: 모달 스피너 후 `ensureTableExtras().then(재호출)`
  - `renderHistory()`: historyContent 스피너 후 `ensureTableExtras().then(재호출)`
- 함수 signature 변경 없음 → 호출자 코드 무영향

## UX
- 페이지 로드 후 1.5초 idle 시점 백그라운드 prefetch — 사용자가 별표 클릭 전 보통 완료
- 로드 실패 시 "🔄 다시 시도" 버튼
- 스피너 메시지 "별표 자료 로딩 중... (첫 클릭 시에만 다운로드)"

## SW 캐시 (γ-5 점검)
- `service-worker.js`에 fetch 핸들러 없음 → 자체 캐싱 안 함
- `?v={build_ts}` 캐시버스팅으로 브라우저 HTTP 캐시만 사용
- lazy load와 충돌 없음

## Test plan
- [ ] 머지 후 viewer.html 첫 로드 빨라졌는지 (Network 탭으로 data_core만 다운로드 확인)
- [ ] 별표 링크 클릭 시 스피너 → 모달 본문 정상 표시
- [ ] 연혁 탭 클릭 시 스피너 → 별표 연혁 정상 표시
- [ ] 7개 그룹 viewer 모두 콘솔 에러 없음
- [ ] 모바일에서 네트워크 느릴 때 스피너 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)