### PR TITLE
fix: 알림받기 버튼이 헤더 통계와 겹치는 문제 해결

### DIFF
--- a/generate_viewer.py
+++ b/generate_viewer.py
@@ -431,8 +431,13 @@ def main():
     else:
         alarm_button = ""
         alarm_modal = ""
-    # 좌측 액션 래퍼 — 알람(road)이 있으면 둘 다, 없으면 튜터만
-    left_actions = f'<div class="header-left-actions">{alarm_button}{tutor_button}</div>'
+    # 좌측 액션 래퍼 — 알람(road) + 튜터 + 알림받기 셋 다 한 flex 그룹으로 묶음
+    # (이전: pushBtn이 우측 absolute라 헤더 통계와 충돌. 사용자 보고 2026-05-27 → 좌측 그룹화)
+    push_button = (
+        '<button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">'
+        '🔔 알림 받기</button>'
+    )
+    left_actions = f'<div class="header-left-actions">{alarm_button}{tutor_button}{push_button}</div>'
     # 튜터 페이지 본인이면 자기 자신으로 가는 버튼 의미 없음 — 하지만 viewer는 튜터가 아니므로 항상 표시
     # 단, road group viewer의 경우 튜터 가는 경로는 ./tutor/, 다른 그룹 viewer도 동일 위치(루트 기준)
     html = html.replace("{{ALARM_BUTTON}}", left_actions).replace("{{ALARM_MODAL}}", alarm_modal)
@@ -510,18 +515,18 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 .header .header-stats{position:absolute;top:14px;right:20px;font-size:11px;opacity:.85;text-align:right;line-height:1.5}
 .header .header-stats b{font-size:14px;display:block;font-weight:600}
 @media(max-width:768px){.header .header-stats{display:none}}
-/* PR-H4-β: 헤더 좌측 액션 그룹 (최근 개정 알림 + 튜터 복귀) — flex 래퍼로 절대좌표 충돌 회피 */
-.header-left-actions{position:absolute;top:12px;left:20px;display:flex;gap:8px;flex-wrap:wrap;z-index:5}
-.header-action-btn{border:none;padding:8px 14px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:inherit;box-shadow:0 2px 4px rgba(0,0,0,0.15);line-height:1.2}
+/* PR-H4-β/fix: 헤더 좌측 액션 그룹 — 3개 버튼 모두 한 flex 컨테이너에 묶어 우측 header-stats와 충돌 회피
+   (이전: pushBtn이 우측 absolute라 통계 표시와 같은 위치에서 겹침) */
+.header-left-actions{position:absolute;top:12px;left:20px;display:flex;gap:8px;flex-wrap:wrap;z-index:5;max-width:calc(100% - 200px)}
+.header-action-btn{border:none;padding:8px 14px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:inherit;box-shadow:0 2px 4px rgba(0,0,0,0.15);line-height:1.2;text-decoration:none}
 .header-action-btn.alarm{background:#c0392b;color:#fff}
 .header-action-btn.tutor{background:#fff;color:var(--law);border:1px solid var(--border)}
-.header-push-link{position:absolute;top:12px;right:20px;padding:8px 14px;border:1px solid var(--border);background:#fff;border-radius:6px;cursor:pointer;font-size:13px;color:var(--law);font-weight:600;z-index:10;box-shadow:0 2px 4px rgba(0,0,0,0.15);display:inline-flex;align-items:center;gap:6px;line-height:1.2}
-/* 모바일에서 헤더 버튼 3개 — 작게 + wrap 허용 (h1 가리지 않게) */
+.header-action-btn.push{background:#fff;color:var(--law);border:1px solid var(--border)}
+/* 모바일에서 헤더 버튼 그룹 — 작게 + wrap 허용 + stats 숨김으로 우측 폭 회수 */
 @media(max-width:600px){
   .header{padding-top:52px}
-  .header-left-actions{top:8px!important;left:8px!important;gap:6px}
+  .header-left-actions{top:8px!important;left:8px!important;gap:6px;max-width:calc(100% - 16px)}
   .header-action-btn{padding:5px 10px!important;font-size:11px!important}
-  .header-push-link{top:8px!important;right:8px!important;padding:5px 10px!important;font-size:11px!important}
 }
 
 .toolbar{background:var(--card);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;position:sticky;top:0;z-index:100;box-shadow:var(--shadow)}
@@ -718,11 +723,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 
 <div class="header" style="position:relative">
   <div class="header-stats" id="headerStats"></div>
-  {{ALARM_BUTTON}}
-  <!-- PR-H2-α / PR-H4-β: 알림 구독 버튼 (우상단) — 좌측 액션과 동일 크기 (color로 위계 구분) -->
-  <button id="pushBtn" type="button" class="header-push-link" onclick="subscribePush()">
-    🔔 알림 받기
-  </button>
+  {{ALARM_BUTTON}}<!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
   <h1>{{LAW_TITLE}} 한눈에</h1>
   <p>법률 · 시행령 · 시행규칙 · 별표 통합 비교</p>
 </div>

--- a/viewer.html
+++ b/viewer.html
@@ -30,18 +30,18 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 .header .header-stats{position:absolute;top:14px;right:20px;font-size:11px;opacity:.85;text-align:right;line-height:1.5}
 .header .header-stats b{font-size:14px;display:block;font-weight:600}
 @media(max-width:768px){.header .header-stats{display:none}}
-/* PR-H4-β: 헤더 좌측 액션 그룹 (최근 개정 알림 + 튜터 복귀) — flex 래퍼로 절대좌표 충돌 회피 */
-.header-left-actions{position:absolute;top:12px;left:20px;display:flex;gap:8px;flex-wrap:wrap;z-index:5}
-.header-action-btn{border:none;padding:8px 14px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:inherit;box-shadow:0 2px 4px rgba(0,0,0,0.15);line-height:1.2}
+/* PR-H4-β/fix: 헤더 좌측 액션 그룹 — 3개 버튼 모두 한 flex 컨테이너에 묶어 우측 header-stats와 충돌 회피
+   (이전: pushBtn이 우측 absolute라 통계 표시와 같은 위치에서 겹침) */
+.header-left-actions{position:absolute;top:12px;left:20px;display:flex;gap:8px;flex-wrap:wrap;z-index:5;max-width:calc(100% - 200px)}
+.header-action-btn{border:none;padding:8px 14px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:inherit;box-shadow:0 2px 4px rgba(0,0,0,0.15);line-height:1.2;text-decoration:none}
 .header-action-btn.alarm{background:#c0392b;color:#fff}
 .header-action-btn.tutor{background:#fff;color:var(--law);border:1px solid var(--border)}
-.header-push-link{position:absolute;top:12px;right:20px;padding:8px 14px;border:1px solid var(--border);background:#fff;border-radius:6px;cursor:pointer;font-size:13px;color:var(--law);font-weight:600;z-index:10;box-shadow:0 2px 4px rgba(0,0,0,0.15);display:inline-flex;align-items:center;gap:6px;line-height:1.2}
-/* 모바일에서 헤더 버튼 3개 — 작게 + wrap 허용 (h1 가리지 않게) */
+.header-action-btn.push{background:#fff;color:var(--law);border:1px solid var(--border)}
+/* 모바일에서 헤더 버튼 그룹 — 작게 + wrap 허용 + stats 숨김으로 우측 폭 회수 */
 @media(max-width:600px){
   .header{padding-top:52px}
-  .header-left-actions{top:8px!important;left:8px!important;gap:6px}
+  .header-left-actions{top:8px!important;left:8px!important;gap:6px;max-width:calc(100% - 16px)}
   .header-action-btn{padding:5px 10px!important;font-size:11px!important}
-  .header-push-link{top:8px!important;right:8px!important;padding:5px 10px!important;font-size:11px!important}
 }
 
 .toolbar{background:var(--card);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;position:sticky;top:0;z-index:100;box-shadow:var(--shadow)}
@@ -238,11 +238,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 
 <div class="header" style="position:relative">
   <div class="header-stats" id="headerStats"></div>
-  <div class="header-left-actions"><button type="button" class="header-action-btn alarm header-alarm-link" id="alarmLink" onclick="openAlarmModal()">📢 최근 개정 알림</button><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a></div>
-  <!-- PR-H2-α / PR-H4-β: 알림 구독 버튼 (우상단) — 좌측 액션과 동일 크기 (color로 위계 구분) -->
-  <button id="pushBtn" type="button" class="header-push-link" onclick="subscribePush()">
-    🔔 알림 받기
-  </button>
+  <div class="header-left-actions"><button type="button" class="header-action-btn alarm header-alarm-link" id="alarmLink" onclick="openAlarmModal()">📢 최근 개정 알림</button><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
   <h1>도로교통법 한눈에</h1>
   <p>법률 · 시행령 · 시행규칙 · 별표 통합 비교</p>
 </div>
@@ -358,7 +354,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core.js?v=20260527001418"></script>
+<script src="web_data/data_core.js?v=20260527002941"></script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -371,7 +367,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527001418';
+const _LAZY_TS = '20260527002941';
 const _LAZY_SFX = '';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_car_mgmt.html
+++ b/viewer_car_mgmt.html
@@ -30,18 +30,18 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 .header .header-stats{position:absolute;top:14px;right:20px;font-size:11px;opacity:.85;text-align:right;line-height:1.5}
 .header .header-stats b{font-size:14px;display:block;font-weight:600}
 @media(max-width:768px){.header .header-stats{display:none}}
-/* PR-H4-β: 헤더 좌측 액션 그룹 (최근 개정 알림 + 튜터 복귀) — flex 래퍼로 절대좌표 충돌 회피 */
-.header-left-actions{position:absolute;top:12px;left:20px;display:flex;gap:8px;flex-wrap:wrap;z-index:5}
-.header-action-btn{border:none;padding:8px 14px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:inherit;box-shadow:0 2px 4px rgba(0,0,0,0.15);line-height:1.2}
+/* PR-H4-β/fix: 헤더 좌측 액션 그룹 — 3개 버튼 모두 한 flex 컨테이너에 묶어 우측 header-stats와 충돌 회피
+   (이전: pushBtn이 우측 absolute라 통계 표시와 같은 위치에서 겹침) */
+.header-left-actions{position:absolute;top:12px;left:20px;display:flex;gap:8px;flex-wrap:wrap;z-index:5;max-width:calc(100% - 200px)}
+.header-action-btn{border:none;padding:8px 14px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:inherit;box-shadow:0 2px 4px rgba(0,0,0,0.15);line-height:1.2;text-decoration:none}
 .header-action-btn.alarm{background:#c0392b;color:#fff}
 .header-action-btn.tutor{background:#fff;color:var(--law);border:1px solid var(--border)}
-.header-push-link{position:absolute;top:12px;right:20px;padding:8px 14px;border:1px solid var(--border);background:#fff;border-radius:6px;cursor:pointer;font-size:13px;color:var(--law);font-weight:600;z-index:10;box-shadow:0 2px 4px rgba(0,0,0,0.15);display:inline-flex;align-items:center;gap:6px;line-height:1.2}
-/* 모바일에서 헤더 버튼 3개 — 작게 + wrap 허용 (h1 가리지 않게) */
+.header-action-btn.push{background:#fff;color:var(--law);border:1px solid var(--border)}
+/* 모바일에서 헤더 버튼 그룹 — 작게 + wrap 허용 + stats 숨김으로 우측 폭 회수 */
 @media(max-width:600px){
   .header{padding-top:52px}
-  .header-left-actions{top:8px!important;left:8px!important;gap:6px}
+  .header-left-actions{top:8px!important;left:8px!important;gap:6px;max-width:calc(100% - 16px)}
   .header-action-btn{padding:5px 10px!important;font-size:11px!important}
-  .header-push-link{top:8px!important;right:8px!important;padding:5px 10px!important;font-size:11px!important}
 }
 
 .toolbar{background:var(--card);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;position:sticky;top:0;z-index:100;box-shadow:var(--shadow)}
@@ -238,11 +238,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 
 <div class="header" style="position:relative">
   <div class="header-stats" id="headerStats"></div>
-  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a></div>
-  <!-- PR-H2-α / PR-H4-β: 알림 구독 버튼 (우상단) — 좌측 액션과 동일 크기 (color로 위계 구분) -->
-  <button id="pushBtn" type="button" class="header-push-link" onclick="subscribePush()">
-    🔔 알림 받기
-  </button>
+  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
   <h1>자동차관리법 한눈에</h1>
   <p>법률 · 시행령 · 시행규칙 · 별표 통합 비교</p>
 </div>
@@ -357,7 +353,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_car_mgmt.js?v=20260527001422"></script>
+<script src="web_data/data_core_car_mgmt.js?v=20260527002945"></script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -370,7 +366,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527001422';
+const _LAZY_TS = '20260527002945';
 const _LAZY_SFX = '_car_mgmt';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_cargo_transport.html
+++ b/viewer_cargo_transport.html
@@ -30,18 +30,18 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 .header .header-stats{position:absolute;top:14px;right:20px;font-size:11px;opacity:.85;text-align:right;line-height:1.5}
 .header .header-stats b{font-size:14px;display:block;font-weight:600}
 @media(max-width:768px){.header .header-stats{display:none}}
-/* PR-H4-β: 헤더 좌측 액션 그룹 (최근 개정 알림 + 튜터 복귀) — flex 래퍼로 절대좌표 충돌 회피 */
-.header-left-actions{position:absolute;top:12px;left:20px;display:flex;gap:8px;flex-wrap:wrap;z-index:5}
-.header-action-btn{border:none;padding:8px 14px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:inherit;box-shadow:0 2px 4px rgba(0,0,0,0.15);line-height:1.2}
+/* PR-H4-β/fix: 헤더 좌측 액션 그룹 — 3개 버튼 모두 한 flex 컨테이너에 묶어 우측 header-stats와 충돌 회피
+   (이전: pushBtn이 우측 absolute라 통계 표시와 같은 위치에서 겹침) */
+.header-left-actions{position:absolute;top:12px;left:20px;display:flex;gap:8px;flex-wrap:wrap;z-index:5;max-width:calc(100% - 200px)}
+.header-action-btn{border:none;padding:8px 14px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:inherit;box-shadow:0 2px 4px rgba(0,0,0,0.15);line-height:1.2;text-decoration:none}
 .header-action-btn.alarm{background:#c0392b;color:#fff}
 .header-action-btn.tutor{background:#fff;color:var(--law);border:1px solid var(--border)}
-.header-push-link{position:absolute;top:12px;right:20px;padding:8px 14px;border:1px solid var(--border);background:#fff;border-radius:6px;cursor:pointer;font-size:13px;color:var(--law);font-weight:600;z-index:10;box-shadow:0 2px 4px rgba(0,0,0,0.15);display:inline-flex;align-items:center;gap:6px;line-height:1.2}
-/* 모바일에서 헤더 버튼 3개 — 작게 + wrap 허용 (h1 가리지 않게) */
+.header-action-btn.push{background:#fff;color:var(--law);border:1px solid var(--border)}
+/* 모바일에서 헤더 버튼 그룹 — 작게 + wrap 허용 + stats 숨김으로 우측 폭 회수 */
 @media(max-width:600px){
   .header{padding-top:52px}
-  .header-left-actions{top:8px!important;left:8px!important;gap:6px}
+  .header-left-actions{top:8px!important;left:8px!important;gap:6px;max-width:calc(100% - 16px)}
   .header-action-btn{padding:5px 10px!important;font-size:11px!important}
-  .header-push-link{top:8px!important;right:8px!important;padding:5px 10px!important;font-size:11px!important}
 }
 
 .toolbar{background:var(--card);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;position:sticky;top:0;z-index:100;box-shadow:var(--shadow)}
@@ -238,11 +238,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 
 <div class="header" style="position:relative">
   <div class="header-stats" id="headerStats"></div>
-  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a></div>
-  <!-- PR-H2-α / PR-H4-β: 알림 구독 버튼 (우상단) — 좌측 액션과 동일 크기 (color로 위계 구분) -->
-  <button id="pushBtn" type="button" class="header-push-link" onclick="subscribePush()">
-    🔔 알림 받기
-  </button>
+  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
   <h1>화물자동차 운수사업법 한눈에</h1>
   <p>법률 · 시행령 · 시행규칙 · 별표 통합 비교</p>
 </div>
@@ -357,7 +353,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_cargo_transport.js?v=20260527001425"></script>
+<script src="web_data/data_core_cargo_transport.js?v=20260527002947"></script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -370,7 +366,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527001425';
+const _LAZY_TS = '20260527002947';
 const _LAZY_SFX = '_cargo_transport';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_crim_proc.html
+++ b/viewer_crim_proc.html
@@ -30,18 +30,18 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 .header .header-stats{position:absolute;top:14px;right:20px;font-size:11px;opacity:.85;text-align:right;line-height:1.5}
 .header .header-stats b{font-size:14px;display:block;font-weight:600}
 @media(max-width:768px){.header .header-stats{display:none}}
-/* PR-H4-β: 헤더 좌측 액션 그룹 (최근 개정 알림 + 튜터 복귀) — flex 래퍼로 절대좌표 충돌 회피 */
-.header-left-actions{position:absolute;top:12px;left:20px;display:flex;gap:8px;flex-wrap:wrap;z-index:5}
-.header-action-btn{border:none;padding:8px 14px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:inherit;box-shadow:0 2px 4px rgba(0,0,0,0.15);line-height:1.2}
+/* PR-H4-β/fix: 헤더 좌측 액션 그룹 — 3개 버튼 모두 한 flex 컨테이너에 묶어 우측 header-stats와 충돌 회피
+   (이전: pushBtn이 우측 absolute라 통계 표시와 같은 위치에서 겹침) */
+.header-left-actions{position:absolute;top:12px;left:20px;display:flex;gap:8px;flex-wrap:wrap;z-index:5;max-width:calc(100% - 200px)}
+.header-action-btn{border:none;padding:8px 14px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:inherit;box-shadow:0 2px 4px rgba(0,0,0,0.15);line-height:1.2;text-decoration:none}
 .header-action-btn.alarm{background:#c0392b;color:#fff}
 .header-action-btn.tutor{background:#fff;color:var(--law);border:1px solid var(--border)}
-.header-push-link{position:absolute;top:12px;right:20px;padding:8px 14px;border:1px solid var(--border);background:#fff;border-radius:6px;cursor:pointer;font-size:13px;color:var(--law);font-weight:600;z-index:10;box-shadow:0 2px 4px rgba(0,0,0,0.15);display:inline-flex;align-items:center;gap:6px;line-height:1.2}
-/* 모바일에서 헤더 버튼 3개 — 작게 + wrap 허용 (h1 가리지 않게) */
+.header-action-btn.push{background:#fff;color:var(--law);border:1px solid var(--border)}
+/* 모바일에서 헤더 버튼 그룹 — 작게 + wrap 허용 + stats 숨김으로 우측 폭 회수 */
 @media(max-width:600px){
   .header{padding-top:52px}
-  .header-left-actions{top:8px!important;left:8px!important;gap:6px}
+  .header-left-actions{top:8px!important;left:8px!important;gap:6px;max-width:calc(100% - 16px)}
   .header-action-btn{padding:5px 10px!important;font-size:11px!important}
-  .header-push-link{top:8px!important;right:8px!important;padding:5px 10px!important;font-size:11px!important}
 }
 
 .toolbar{background:var(--card);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;position:sticky;top:0;z-index:100;box-shadow:var(--shadow)}
@@ -238,11 +238,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 
 <div class="header" style="position:relative">
   <div class="header-stats" id="headerStats"></div>
-  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a></div>
-  <!-- PR-H2-α / PR-H4-β: 알림 구독 버튼 (우상단) — 좌측 액션과 동일 크기 (color로 위계 구분) -->
-  <button id="pushBtn" type="button" class="header-push-link" onclick="subscribePush()">
-    🔔 알림 받기
-  </button>
+  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
   <h1>형사소송법 한눈에</h1>
   <p>법률 · 시행령 · 시행규칙 · 별표 통합 비교</p>
 </div>
@@ -357,7 +353,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_crim_proc.js?v=20260527001425"></script>
+<script src="web_data/data_core_crim_proc.js?v=20260527002948"></script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -370,7 +366,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527001425';
+const _LAZY_TS = '20260527002948';
 const _LAZY_SFX = '_crim_proc';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_passenger_transport.html
+++ b/viewer_passenger_transport.html
@@ -30,18 +30,18 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 .header .header-stats{position:absolute;top:14px;right:20px;font-size:11px;opacity:.85;text-align:right;line-height:1.5}
 .header .header-stats b{font-size:14px;display:block;font-weight:600}
 @media(max-width:768px){.header .header-stats{display:none}}
-/* PR-H4-β: 헤더 좌측 액션 그룹 (최근 개정 알림 + 튜터 복귀) — flex 래퍼로 절대좌표 충돌 회피 */
-.header-left-actions{position:absolute;top:12px;left:20px;display:flex;gap:8px;flex-wrap:wrap;z-index:5}
-.header-action-btn{border:none;padding:8px 14px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:inherit;box-shadow:0 2px 4px rgba(0,0,0,0.15);line-height:1.2}
+/* PR-H4-β/fix: 헤더 좌측 액션 그룹 — 3개 버튼 모두 한 flex 컨테이너에 묶어 우측 header-stats와 충돌 회피
+   (이전: pushBtn이 우측 absolute라 통계 표시와 같은 위치에서 겹침) */
+.header-left-actions{position:absolute;top:12px;left:20px;display:flex;gap:8px;flex-wrap:wrap;z-index:5;max-width:calc(100% - 200px)}
+.header-action-btn{border:none;padding:8px 14px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:inherit;box-shadow:0 2px 4px rgba(0,0,0,0.15);line-height:1.2;text-decoration:none}
 .header-action-btn.alarm{background:#c0392b;color:#fff}
 .header-action-btn.tutor{background:#fff;color:var(--law);border:1px solid var(--border)}
-.header-push-link{position:absolute;top:12px;right:20px;padding:8px 14px;border:1px solid var(--border);background:#fff;border-radius:6px;cursor:pointer;font-size:13px;color:var(--law);font-weight:600;z-index:10;box-shadow:0 2px 4px rgba(0,0,0,0.15);display:inline-flex;align-items:center;gap:6px;line-height:1.2}
-/* 모바일에서 헤더 버튼 3개 — 작게 + wrap 허용 (h1 가리지 않게) */
+.header-action-btn.push{background:#fff;color:var(--law);border:1px solid var(--border)}
+/* 모바일에서 헤더 버튼 그룹 — 작게 + wrap 허용 + stats 숨김으로 우측 폭 회수 */
 @media(max-width:600px){
   .header{padding-top:52px}
-  .header-left-actions{top:8px!important;left:8px!important;gap:6px}
+  .header-left-actions{top:8px!important;left:8px!important;gap:6px;max-width:calc(100% - 16px)}
   .header-action-btn{padding:5px 10px!important;font-size:11px!important}
-  .header-push-link{top:8px!important;right:8px!important;padding:5px 10px!important;font-size:11px!important}
 }
 
 .toolbar{background:var(--card);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;position:sticky;top:0;z-index:100;box-shadow:var(--shadow)}
@@ -238,11 +238,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 
 <div class="header" style="position:relative">
   <div class="header-stats" id="headerStats"></div>
-  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a></div>
-  <!-- PR-H2-α / PR-H4-β: 알림 구독 버튼 (우상단) — 좌측 액션과 동일 크기 (color로 위계 구분) -->
-  <button id="pushBtn" type="button" class="header-push-link" onclick="subscribePush()">
-    🔔 알림 받기
-  </button>
+  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
   <h1>여객자동차 운수사업법 한눈에</h1>
   <p>법률 · 시행령 · 시행규칙 · 별표 통합 비교</p>
 </div>
@@ -357,7 +353,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_passenger_transport.js?v=20260527001424"></script>
+<script src="web_data/data_core_passenger_transport.js?v=20260527002946"></script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -370,7 +366,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527001424';
+const _LAZY_TS = '20260527002946';
 const _LAZY_SFX = '_passenger_transport';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_tkga.html
+++ b/viewer_tkga.html
@@ -30,18 +30,18 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 .header .header-stats{position:absolute;top:14px;right:20px;font-size:11px;opacity:.85;text-align:right;line-height:1.5}
 .header .header-stats b{font-size:14px;display:block;font-weight:600}
 @media(max-width:768px){.header .header-stats{display:none}}
-/* PR-H4-β: 헤더 좌측 액션 그룹 (최근 개정 알림 + 튜터 복귀) — flex 래퍼로 절대좌표 충돌 회피 */
-.header-left-actions{position:absolute;top:12px;left:20px;display:flex;gap:8px;flex-wrap:wrap;z-index:5}
-.header-action-btn{border:none;padding:8px 14px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:inherit;box-shadow:0 2px 4px rgba(0,0,0,0.15);line-height:1.2}
+/* PR-H4-β/fix: 헤더 좌측 액션 그룹 — 3개 버튼 모두 한 flex 컨테이너에 묶어 우측 header-stats와 충돌 회피
+   (이전: pushBtn이 우측 absolute라 통계 표시와 같은 위치에서 겹침) */
+.header-left-actions{position:absolute;top:12px;left:20px;display:flex;gap:8px;flex-wrap:wrap;z-index:5;max-width:calc(100% - 200px)}
+.header-action-btn{border:none;padding:8px 14px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:inherit;box-shadow:0 2px 4px rgba(0,0,0,0.15);line-height:1.2;text-decoration:none}
 .header-action-btn.alarm{background:#c0392b;color:#fff}
 .header-action-btn.tutor{background:#fff;color:var(--law);border:1px solid var(--border)}
-.header-push-link{position:absolute;top:12px;right:20px;padding:8px 14px;border:1px solid var(--border);background:#fff;border-radius:6px;cursor:pointer;font-size:13px;color:var(--law);font-weight:600;z-index:10;box-shadow:0 2px 4px rgba(0,0,0,0.15);display:inline-flex;align-items:center;gap:6px;line-height:1.2}
-/* 모바일에서 헤더 버튼 3개 — 작게 + wrap 허용 (h1 가리지 않게) */
+.header-action-btn.push{background:#fff;color:var(--law);border:1px solid var(--border)}
+/* 모바일에서 헤더 버튼 그룹 — 작게 + wrap 허용 + stats 숨김으로 우측 폭 회수 */
 @media(max-width:600px){
   .header{padding-top:52px}
-  .header-left-actions{top:8px!important;left:8px!important;gap:6px}
+  .header-left-actions{top:8px!important;left:8px!important;gap:6px;max-width:calc(100% - 16px)}
   .header-action-btn{padding:5px 10px!important;font-size:11px!important}
-  .header-push-link{top:8px!important;right:8px!important;padding:5px 10px!important;font-size:11px!important}
 }
 
 .toolbar{background:var(--card);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;position:sticky;top:0;z-index:100;box-shadow:var(--shadow)}
@@ -238,11 +238,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 
 <div class="header" style="position:relative">
   <div class="header-stats" id="headerStats"></div>
-  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a></div>
-  <!-- PR-H2-α / PR-H4-β: 알림 구독 버튼 (우상단) — 좌측 액션과 동일 크기 (color로 위계 구분) -->
-  <button id="pushBtn" type="button" class="header-push-link" onclick="subscribePush()">
-    🔔 알림 받기
-  </button>
+  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
   <h1>특정범죄 가중처벌 등에 관한 법률 한눈에</h1>
   <p>법률 · 시행령 · 시행규칙 · 별표 통합 비교</p>
 </div>
@@ -357,7 +353,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_tkga.js?v=20260527001419"></script>
+<script src="web_data/data_core_tkga.js?v=20260527002942"></script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -370,7 +366,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527001419';
+const _LAZY_TS = '20260527002942';
 const _LAZY_SFX = '_tkga';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_tlspc.html
+++ b/viewer_tlspc.html
@@ -30,18 +30,18 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 .header .header-stats{position:absolute;top:14px;right:20px;font-size:11px;opacity:.85;text-align:right;line-height:1.5}
 .header .header-stats b{font-size:14px;display:block;font-weight:600}
 @media(max-width:768px){.header .header-stats{display:none}}
-/* PR-H4-β: 헤더 좌측 액션 그룹 (최근 개정 알림 + 튜터 복귀) — flex 래퍼로 절대좌표 충돌 회피 */
-.header-left-actions{position:absolute;top:12px;left:20px;display:flex;gap:8px;flex-wrap:wrap;z-index:5}
-.header-action-btn{border:none;padding:8px 14px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:inherit;box-shadow:0 2px 4px rgba(0,0,0,0.15);line-height:1.2}
+/* PR-H4-β/fix: 헤더 좌측 액션 그룹 — 3개 버튼 모두 한 flex 컨테이너에 묶어 우측 header-stats와 충돌 회피
+   (이전: pushBtn이 우측 absolute라 통계 표시와 같은 위치에서 겹침) */
+.header-left-actions{position:absolute;top:12px;left:20px;display:flex;gap:8px;flex-wrap:wrap;z-index:5;max-width:calc(100% - 200px)}
+.header-action-btn{border:none;padding:8px 14px;border-radius:6px;font-size:13px;font-weight:600;cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-family:inherit;box-shadow:0 2px 4px rgba(0,0,0,0.15);line-height:1.2;text-decoration:none}
 .header-action-btn.alarm{background:#c0392b;color:#fff}
 .header-action-btn.tutor{background:#fff;color:var(--law);border:1px solid var(--border)}
-.header-push-link{position:absolute;top:12px;right:20px;padding:8px 14px;border:1px solid var(--border);background:#fff;border-radius:6px;cursor:pointer;font-size:13px;color:var(--law);font-weight:600;z-index:10;box-shadow:0 2px 4px rgba(0,0,0,0.15);display:inline-flex;align-items:center;gap:6px;line-height:1.2}
-/* 모바일에서 헤더 버튼 3개 — 작게 + wrap 허용 (h1 가리지 않게) */
+.header-action-btn.push{background:#fff;color:var(--law);border:1px solid var(--border)}
+/* 모바일에서 헤더 버튼 그룹 — 작게 + wrap 허용 + stats 숨김으로 우측 폭 회수 */
 @media(max-width:600px){
   .header{padding-top:52px}
-  .header-left-actions{top:8px!important;left:8px!important;gap:6px}
+  .header-left-actions{top:8px!important;left:8px!important;gap:6px;max-width:calc(100% - 16px)}
   .header-action-btn{padding:5px 10px!important;font-size:11px!important}
-  .header-push-link{top:8px!important;right:8px!important;padding:5px 10px!important;font-size:11px!important}
 }
 
 .toolbar{background:var(--card);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;position:sticky;top:0;z-index:100;box-shadow:var(--shadow)}
@@ -238,11 +238,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 
 <div class="header" style="position:relative">
   <div class="header-stats" id="headerStats"></div>
-  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a></div>
-  <!-- PR-H2-α / PR-H4-β: 알림 구독 버튼 (우상단) — 좌측 액션과 동일 크기 (color로 위계 구분) -->
-  <button id="pushBtn" type="button" class="header-push-link" onclick="subscribePush()">
-    🔔 알림 받기
-  </button>
+  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
   <h1>교통사고처리 특례법 한눈에</h1>
   <p>법률 · 시행령 · 시행규칙 · 별표 통합 비교</p>
 </div>
@@ -357,7 +353,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_tlspc.js?v=20260527001419"></script>
+<script src="web_data/data_core_tlspc.js?v=20260527002942"></script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -370,7 +366,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527001419';
+const _LAZY_TS = '20260527002942';
 const _LAZY_SFX = '_tlspc';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){


### PR DESCRIPTION
## 문제
사용자 보고 (2026-05-27, PC 데스크톱):
- `🔔 알림 받기` 버튼이 헤더 우측 상단의 `📊 105 하위법령 매핑` 통계 표시와 겹쳐서 표시됨
- 원인: 둘 다 `position:absolute; top:~12px; right:20px`로 같은 위치를 점유

## 해결
3개 버튼(알람·튜터·알림받기) 모두 좌측 `.header-left-actions` flex 컨테이너에 통합:
- 우측 상단은 header-stats(통계)만 남김
- 알림받기 absolute 위치 제거 → `.header-action-btn.push` 클래스로 일반 flex 아이템 처리
- `max-width:calc(100% - 200px)`로 통계 영역 침범 가드
- 모바일에서 stats 숨김 + 좌측 그룹 max-width 확장

## 변경
- generate_viewer.py (CSS + 버튼 정의 일부)
- viewer*.html 7개 재생성

## Test plan
- [ ] 머지 후 viewer.html에서 좌측 상단 세 버튼이 한 줄(또는 wrap)로 가지런히 표시
- [ ] 우측 상단에 `105 하위법령 매핑` 통계만 보임 (버튼 겹침 없음)
- [ ] 헤더 폭이 좁아져도 셋 다 좌측에서 자연스럽게 wrap
- [ ] 알림 받기 버튼 클릭 시 subscribePush 정상 동작 (id="pushBtn" 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)