### PR TITLE
fix: 모바일 헤더 버튼-h1 겹침 해결 (자연 흐름 stacking)

### DIFF
--- a/generate_viewer.py
+++ b/generate_viewer.py
@@ -522,11 +522,13 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 .header-action-btn.alarm{background:#c0392b;color:#fff}
 .header-action-btn.tutor{background:#fff;color:var(--law);border:1px solid var(--border)}
 .header-action-btn.push{background:#fff;color:var(--law);border:1px solid var(--border)}
-/* 모바일에서 헤더 버튼 그룹 — 작게 + wrap 허용 + stats 숨김으로 우측 폭 회수 */
+/* 모바일에서 헤더 버튼 그룹 — absolute 빼고 자연 흐름으로 위→아래 stacking (h1 겹침 회피) */
 @media(max-width:600px){
-  .header{padding-top:52px}
-  .header-left-actions{top:8px!important;left:8px!important;gap:6px;max-width:calc(100% - 16px)}
-  .header-action-btn{padding:5px 10px!important;font-size:11px!important}
+  .header{padding:14px 14px 16px;display:flex;flex-direction:column;align-items:stretch}
+  .header-left-actions{position:static!important;top:auto!important;left:auto!important;display:flex;justify-content:center;gap:6px;max-width:100%;margin-bottom:10px;flex-wrap:wrap}
+  .header-action-btn{padding:6px 10px!important;font-size:11px!important;flex-shrink:0}
+  .header h1{font-size:18px}
+  .header p{font-size:12px}
 }
 
 .toolbar{background:var(--card);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;position:sticky;top:0;z-index:100;box-shadow:var(--shadow)}

--- a/viewer.html
+++ b/viewer.html
@@ -37,11 +37,13 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 .header-action-btn.alarm{background:#c0392b;color:#fff}
 .header-action-btn.tutor{background:#fff;color:var(--law);border:1px solid var(--border)}
 .header-action-btn.push{background:#fff;color:var(--law);border:1px solid var(--border)}
-/* 모바일에서 헤더 버튼 그룹 — 작게 + wrap 허용 + stats 숨김으로 우측 폭 회수 */
+/* 모바일에서 헤더 버튼 그룹 — absolute 빼고 자연 흐름으로 위→아래 stacking (h1 겹침 회피) */
 @media(max-width:600px){
-  .header{padding-top:52px}
-  .header-left-actions{top:8px!important;left:8px!important;gap:6px;max-width:calc(100% - 16px)}
-  .header-action-btn{padding:5px 10px!important;font-size:11px!important}
+  .header{padding:14px 14px 16px;display:flex;flex-direction:column;align-items:stretch}
+  .header-left-actions{position:static!important;top:auto!important;left:auto!important;display:flex;justify-content:center;gap:6px;max-width:100%;margin-bottom:10px;flex-wrap:wrap}
+  .header-action-btn{padding:6px 10px!important;font-size:11px!important;flex-shrink:0}
+  .header h1{font-size:18px}
+  .header p{font-size:12px}
 }
 
 .toolbar{background:var(--card);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;position:sticky;top:0;z-index:100;box-shadow:var(--shadow)}
@@ -354,7 +356,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core.js?v=20260527002941"></script>
+<script src="web_data/data_core.js?v=20260527004042"></script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -367,7 +369,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527002941';
+const _LAZY_TS = '20260527004042';
 const _LAZY_SFX = '';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_car_mgmt.html
+++ b/viewer_car_mgmt.html
@@ -37,11 +37,13 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 .header-action-btn.alarm{background:#c0392b;color:#fff}
 .header-action-btn.tutor{background:#fff;color:var(--law);border:1px solid var(--border)}
 .header-action-btn.push{background:#fff;color:var(--law);border:1px solid var(--border)}
-/* 모바일에서 헤더 버튼 그룹 — 작게 + wrap 허용 + stats 숨김으로 우측 폭 회수 */
+/* 모바일에서 헤더 버튼 그룹 — absolute 빼고 자연 흐름으로 위→아래 stacking (h1 겹침 회피) */
 @media(max-width:600px){
-  .header{padding-top:52px}
-  .header-left-actions{top:8px!important;left:8px!important;gap:6px;max-width:calc(100% - 16px)}
-  .header-action-btn{padding:5px 10px!important;font-size:11px!important}
+  .header{padding:14px 14px 16px;display:flex;flex-direction:column;align-items:stretch}
+  .header-left-actions{position:static!important;top:auto!important;left:auto!important;display:flex;justify-content:center;gap:6px;max-width:100%;margin-bottom:10px;flex-wrap:wrap}
+  .header-action-btn{padding:6px 10px!important;font-size:11px!important;flex-shrink:0}
+  .header h1{font-size:18px}
+  .header p{font-size:12px}
 }
 
 .toolbar{background:var(--card);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;position:sticky;top:0;z-index:100;box-shadow:var(--shadow)}
@@ -353,7 +355,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_car_mgmt.js?v=20260527002945"></script>
+<script src="web_data/data_core_car_mgmt.js?v=20260527004045"></script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -366,7 +368,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527002945';
+const _LAZY_TS = '20260527004045';
 const _LAZY_SFX = '_car_mgmt';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_cargo_transport.html
+++ b/viewer_cargo_transport.html
@@ -37,11 +37,13 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 .header-action-btn.alarm{background:#c0392b;color:#fff}
 .header-action-btn.tutor{background:#fff;color:var(--law);border:1px solid var(--border)}
 .header-action-btn.push{background:#fff;color:var(--law);border:1px solid var(--border)}
-/* 모바일에서 헤더 버튼 그룹 — 작게 + wrap 허용 + stats 숨김으로 우측 폭 회수 */
+/* 모바일에서 헤더 버튼 그룹 — absolute 빼고 자연 흐름으로 위→아래 stacking (h1 겹침 회피) */
 @media(max-width:600px){
-  .header{padding-top:52px}
-  .header-left-actions{top:8px!important;left:8px!important;gap:6px;max-width:calc(100% - 16px)}
-  .header-action-btn{padding:5px 10px!important;font-size:11px!important}
+  .header{padding:14px 14px 16px;display:flex;flex-direction:column;align-items:stretch}
+  .header-left-actions{position:static!important;top:auto!important;left:auto!important;display:flex;justify-content:center;gap:6px;max-width:100%;margin-bottom:10px;flex-wrap:wrap}
+  .header-action-btn{padding:6px 10px!important;font-size:11px!important;flex-shrink:0}
+  .header h1{font-size:18px}
+  .header p{font-size:12px}
 }
 
 .toolbar{background:var(--card);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;position:sticky;top:0;z-index:100;box-shadow:var(--shadow)}
@@ -353,7 +355,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_cargo_transport.js?v=20260527002947"></script>
+<script src="web_data/data_core_cargo_transport.js?v=20260527004047"></script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -366,7 +368,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527002947';
+const _LAZY_TS = '20260527004047';
 const _LAZY_SFX = '_cargo_transport';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_crim_proc.html
+++ b/viewer_crim_proc.html
@@ -37,11 +37,13 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 .header-action-btn.alarm{background:#c0392b;color:#fff}
 .header-action-btn.tutor{background:#fff;color:var(--law);border:1px solid var(--border)}
 .header-action-btn.push{background:#fff;color:var(--law);border:1px solid var(--border)}
-/* 모바일에서 헤더 버튼 그룹 — 작게 + wrap 허용 + stats 숨김으로 우측 폭 회수 */
+/* 모바일에서 헤더 버튼 그룹 — absolute 빼고 자연 흐름으로 위→아래 stacking (h1 겹침 회피) */
 @media(max-width:600px){
-  .header{padding-top:52px}
-  .header-left-actions{top:8px!important;left:8px!important;gap:6px;max-width:calc(100% - 16px)}
-  .header-action-btn{padding:5px 10px!important;font-size:11px!important}
+  .header{padding:14px 14px 16px;display:flex;flex-direction:column;align-items:stretch}
+  .header-left-actions{position:static!important;top:auto!important;left:auto!important;display:flex;justify-content:center;gap:6px;max-width:100%;margin-bottom:10px;flex-wrap:wrap}
+  .header-action-btn{padding:6px 10px!important;font-size:11px!important;flex-shrink:0}
+  .header h1{font-size:18px}
+  .header p{font-size:12px}
 }
 
 .toolbar{background:var(--card);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;position:sticky;top:0;z-index:100;box-shadow:var(--shadow)}
@@ -353,7 +355,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_crim_proc.js?v=20260527002948"></script>
+<script src="web_data/data_core_crim_proc.js?v=20260527004047"></script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -366,7 +368,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527002948';
+const _LAZY_TS = '20260527004047';
 const _LAZY_SFX = '_crim_proc';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_passenger_transport.html
+++ b/viewer_passenger_transport.html
@@ -37,11 +37,13 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 .header-action-btn.alarm{background:#c0392b;color:#fff}
 .header-action-btn.tutor{background:#fff;color:var(--law);border:1px solid var(--border)}
 .header-action-btn.push{background:#fff;color:var(--law);border:1px solid var(--border)}
-/* 모바일에서 헤더 버튼 그룹 — 작게 + wrap 허용 + stats 숨김으로 우측 폭 회수 */
+/* 모바일에서 헤더 버튼 그룹 — absolute 빼고 자연 흐름으로 위→아래 stacking (h1 겹침 회피) */
 @media(max-width:600px){
-  .header{padding-top:52px}
-  .header-left-actions{top:8px!important;left:8px!important;gap:6px;max-width:calc(100% - 16px)}
-  .header-action-btn{padding:5px 10px!important;font-size:11px!important}
+  .header{padding:14px 14px 16px;display:flex;flex-direction:column;align-items:stretch}
+  .header-left-actions{position:static!important;top:auto!important;left:auto!important;display:flex;justify-content:center;gap:6px;max-width:100%;margin-bottom:10px;flex-wrap:wrap}
+  .header-action-btn{padding:6px 10px!important;font-size:11px!important;flex-shrink:0}
+  .header h1{font-size:18px}
+  .header p{font-size:12px}
 }
 
 .toolbar{background:var(--card);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;position:sticky;top:0;z-index:100;box-shadow:var(--shadow)}
@@ -353,7 +355,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_passenger_transport.js?v=20260527002946"></script>
+<script src="web_data/data_core_passenger_transport.js?v=20260527004046"></script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -366,7 +368,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527002946';
+const _LAZY_TS = '20260527004046';
 const _LAZY_SFX = '_passenger_transport';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_tkga.html
+++ b/viewer_tkga.html
@@ -37,11 +37,13 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 .header-action-btn.alarm{background:#c0392b;color:#fff}
 .header-action-btn.tutor{background:#fff;color:var(--law);border:1px solid var(--border)}
 .header-action-btn.push{background:#fff;color:var(--law);border:1px solid var(--border)}
-/* 모바일에서 헤더 버튼 그룹 — 작게 + wrap 허용 + stats 숨김으로 우측 폭 회수 */
+/* 모바일에서 헤더 버튼 그룹 — absolute 빼고 자연 흐름으로 위→아래 stacking (h1 겹침 회피) */
 @media(max-width:600px){
-  .header{padding-top:52px}
-  .header-left-actions{top:8px!important;left:8px!important;gap:6px;max-width:calc(100% - 16px)}
-  .header-action-btn{padding:5px 10px!important;font-size:11px!important}
+  .header{padding:14px 14px 16px;display:flex;flex-direction:column;align-items:stretch}
+  .header-left-actions{position:static!important;top:auto!important;left:auto!important;display:flex;justify-content:center;gap:6px;max-width:100%;margin-bottom:10px;flex-wrap:wrap}
+  .header-action-btn{padding:6px 10px!important;font-size:11px!important;flex-shrink:0}
+  .header h1{font-size:18px}
+  .header p{font-size:12px}
 }
 
 .toolbar{background:var(--card);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;position:sticky;top:0;z-index:100;box-shadow:var(--shadow)}
@@ -353,7 +355,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_tkga.js?v=20260527002942"></script>
+<script src="web_data/data_core_tkga.js?v=20260527004043"></script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -366,7 +368,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527002942';
+const _LAZY_TS = '20260527004043';
 const _LAZY_SFX = '_tkga';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_tlspc.html
+++ b/viewer_tlspc.html
@@ -37,11 +37,13 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 .header-action-btn.alarm{background:#c0392b;color:#fff}
 .header-action-btn.tutor{background:#fff;color:var(--law);border:1px solid var(--border)}
 .header-action-btn.push{background:#fff;color:var(--law);border:1px solid var(--border)}
-/* 모바일에서 헤더 버튼 그룹 — 작게 + wrap 허용 + stats 숨김으로 우측 폭 회수 */
+/* 모바일에서 헤더 버튼 그룹 — absolute 빼고 자연 흐름으로 위→아래 stacking (h1 겹침 회피) */
 @media(max-width:600px){
-  .header{padding-top:52px}
-  .header-left-actions{top:8px!important;left:8px!important;gap:6px;max-width:calc(100% - 16px)}
-  .header-action-btn{padding:5px 10px!important;font-size:11px!important}
+  .header{padding:14px 14px 16px;display:flex;flex-direction:column;align-items:stretch}
+  .header-left-actions{position:static!important;top:auto!important;left:auto!important;display:flex;justify-content:center;gap:6px;max-width:100%;margin-bottom:10px;flex-wrap:wrap}
+  .header-action-btn{padding:6px 10px!important;font-size:11px!important;flex-shrink:0}
+  .header h1{font-size:18px}
+  .header p{font-size:12px}
 }
 
 .toolbar{background:var(--card);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;position:sticky;top:0;z-index:100;box-shadow:var(--shadow)}
@@ -353,7 +355,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_tlspc.js?v=20260527002942"></script>
+<script src="web_data/data_core_tlspc.js?v=20260527004042"></script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -366,7 +368,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527002942';
+const _LAZY_TS = '20260527004042';
 const _LAZY_SFX = '_tlspc';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){


### PR DESCRIPTION
## 문제
사용자 모바일 캡처(2026-05-27, Screenshot_20260527_003710_Chrome.jpg) 확인:
- 3버튼(최근 개정 알림·출근길 튜터·구독 중)이 absolute 배치라 한 줄에 들어가긴 했으나 h1 "도로교통법 한눈에"와 겹침
- 모바일 padding-top:52px로도 부족

## 해결
모바일(`@media max-width:600px`)에서만 absolute → 자연 흐름 stacking:
- `.header` flex column 컨테이너
- `.header-left-actions` position:static → 첫 번째 flex 아이템 (가운데 정렬, wrap 허용)
- 그 아래 자연스럽게 h1·p
- h1·p font-size 약간 축소 (18px/12px)

데스크탑(>=601px)은 기존 absolute 레이아웃 그대로.

## Test plan
- [ ] 모바일에서 viewer 새로고침 후 위→아래 stacking 정상
- [ ] h1 "도로교통법 한눈에" 가려지지 않음
- [ ] 데스크탑 레이아웃 회귀 없음 (3버튼 좌상단·통계 우상단)

🤖 Generated with [Claude Code](https://claude.com/claude-code)