### PR TITLE
fix: cron이 카드 push 후 Pages 배포 자동 트리거

### DIFF
--- a/.github/workflows/daily_push.yml
+++ b/.github/workflows/daily_push.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write              # 카드 자료 commit·push 위해 필요
+  actions: write               # deploy_pages workflow_dispatch 트리거 위해 필요 (github-actions[bot] push가 자동 재trigger 안 되는 정책 우회)
 
 jobs:
   build-and-push:
@@ -61,6 +62,7 @@ jobs:
           python build_tutor_content.py --date ${{ steps.date.outputs.today }} --days 1
 
       - name: 카드 자료 commit·push (master)
+        id: card_commit
         continue-on-error: true   # push race로 rejected돼도 알림 발송은 계속 진행
         run: |
           git config user.name 'github-actions[bot]'
@@ -68,12 +70,26 @@ jobs:
           git add tutor/data/daily_*.json tutor/data/schedule.json
           if git diff --cached --quiet; then
             echo "변경 없음 — commit 스킵"
+            echo "pushed=false" >> $GITHUB_OUTPUT
             exit 0
           fi
           git commit -m "data: ${{ steps.date.outputs.today }} 카드 자동 빌드"
           # PR 머지·재trigger와 race 회피 — rebase 후 push, 그래도 실패하면 무시
           git pull --rebase origin master || true
-          git push origin master || echo "⚠️ push 실패 — race condition. 알림 발송은 계속 진행"
+          if git push origin master; then
+            echo "pushed=true" >> $GITHUB_OUTPUT
+          else
+            echo "⚠️ push 실패 — race condition. 알림 발송은 계속 진행"
+            echo "pushed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Pages 배포 트리거 (github-actions[bot] push는 자동 재trigger 안 됨)
+        if: steps.card_commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run deploy_pages.yml --ref master
+          echo "✅ deploy_pages workflow_dispatch 트리거 완료"
 
       - name: 푸시 알림 발송
         env:


### PR DESCRIPTION
## 문제
사용자 보고(2026-05-27 아침):
- 푸시 알림은 도착했지만 모바일 튜터에서 오늘 카드가 안 보임
- 원인 확인: cron이 `github-actions[bot]`으로 master에 카드 push했지만 deploy_pages 워크플로우가 자동 실행되지 않음
- GitHub 정책: `GITHUB_TOKEN`으로 push된 commit은 다른 workflow를 트리거하지 않음 (재귀 방지)

## 해결
1. `카드 자료 commit·push` step에 `id: card_commit` 부여
2. push 성공 여부를 `outputs.pushed`로 전파
3. 새 step에서 `pushed=true`일 때 `gh workflow run deploy_pages.yml`로 명시적 트리거
4. permissions에 `actions: write` 추가

## 효과
- 다음 cron 실행(평일 06:30 KST)부터 카드 push → Pages 배포 자동 연결
- 사용자가 알림 받을 즈음엔 새 카드가 viewer/tutor에 반영

## 오늘 카드 복구
별도로 `gh workflow run deploy_pages.yml --ref master` 수동 실행함 (1회성)

## Test plan
- [ ] 머지 후 다음 평일(2026-05-28 목) cron 자동 실행 모니터링
- [ ] daily_push 끝난 직후 deploy_pages가 workflow_dispatch로 트리거되는지
- [ ] Pages 반영 후 모바일에서 새 카드 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)