### PR TITLE
fix: 사건번호 '도' 자 폰트 도드라짐 해결

### DIFF
--- a/tutor/index.html
+++ b/tutor/index.html
@@ -118,9 +118,12 @@ header a { color: #ffe; text-decoration: underline; }
 }
 .case-head { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; flex-wrap: wrap; }
 .case-no {
-  font-family: 'Courier New', monospace; font-size: 12px; font-weight: 600;
+  /* PR-H5-fix: 폰트 통일 — Courier New는 한글 글리프 없어 '도' 자만 fallback 폰트로
+     도드라지던 문제 해결 (사용자 보고). 강조는 배경·테두리만으로 충분. */
+  font-size: 12px; font-weight: 600;
   color: var(--sub); background: var(--card); padding: 2px 8px;
   border-radius: 4px; border: 1px solid var(--border);
+  font-variant-numeric: tabular-nums;
 }
 .case-type {
   font-size: 10px; font-weight: 700; padding: 2px 7px; border-radius: 3px;


### PR DESCRIPTION
## 사용자 보고
tutor 카드 하단 판례·행정심판례 영역의 사건번호 `2018도10327`에서 한글 **'도'** 자만 폰트가 다르게 도드라져 보임.

## 원인
`.case-no` 클래스가 `font-family: 'Courier New', monospace` 사용:
- Courier New: 영문·숫자 전용 — **한글 글리프 없음**
- 시스템 fallback으로 '도'만 다른 한글 폰트로 렌더링
- 결과: `2018`·`10327` = Courier New / `도` = fallback → 시각적 불일치

## 수정
- monospace 제거 → 본문 폰트(Noto Sans KR)로 통일
- 시각적 강조는 기존 배경·테두리·padding으로 충분 (chip 형태 유지)
- 숫자 정렬을 위해 `font-variant-numeric: tabular-nums` (OpenType, 등폭 숫자)

## Test plan
- [ ] PWA 종료→재진입 후 사건번호 영역 폰트 일관성 확인
- [ ] 한글·숫자 모두 같은 폰트(Noto Sans KR)로 렌더링되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)