### PR TITLE
PR-H5-ζ: 누출 폴백 카드 전용 안전 모드 안내 메시지

### DIFF
--- a/tutor/index.html
+++ b/tutor/index.html
@@ -363,10 +363,19 @@ function renderMainCard(card) {
       + '<p class="explanation">' + esc(lc.explanation) + '</p>'
       + '</article>';
   }
-  // Phase 3 S5 — simple_other_group은 LLM 미수행이 정상. 조문 본문이 풍부하므로 안내 메시지 톤 다르게.
-  const banner = card.llm_status === 'simple_other_group'
-    ? '<div class="llm-skip-banner" style="background:#f3f4f6;color:#374151;border-color:#d1d5db">📘 ' + esc(lawName) + ' 조문 — LLM 학습 콘텐츠는 향후 확장 예정. 조문 본문 위주로 확인하세요.</div>'
-    : '<div class="llm-skip-banner">⚠️ 이 날짜는 학습 콘텐츠가 아직 생성되지 않았습니다 (' + esc(card.llm_status) + '). 조문 정보만 표시합니다.</div>';
+  // 상태별 안내 메시지 — 사용자에게 내부 상태명 노출 최소화 + 의미 명확화
+  // Phase 3 S5 — simple_other_group은 LLM 미수행이 정상. 조문 본문이 풍부하므로 톤 다르게.
+  // PR-H5-ζ — skip_external_keywords_leaked 전용 안전 모드 메시지 (할루시네이션 차단됨)
+  let banner;
+  if (card.llm_status === 'simple_other_group') {
+    banner = '<div class="llm-skip-banner" style="background:#f3f4f6;color:#374151;border-color:#d1d5db">📘 ' + esc(lawName) + ' 조문 — LLM 학습 콘텐츠는 향후 확장 예정. 조문 본문 위주로 확인하세요.</div>';
+  } else if (card.llm_status === 'skip_external_keywords_leaked') {
+    const leakedThemes = (card.verification && card.verification.external_keywords_leaked) || [];
+    const themeStr = leakedThemes.length ? ' (' + leakedThemes.join('·') + ')' : '';
+    banner = '<div class="llm-skip-banner" style="background:#eff6ff;color:#1e3a8a;border-color:#bfdbfe">🛡️ 안전 모드 — 자동 콘텐츠 검증에서 이 조문에 없는 다른 조문 키워드' + esc(themeStr) + '가 감지되어 조문 원문만 표시합니다. (잘못된 학습 콘텐츠 노출 방지)</div>';
+  } else {
+    banner = '<div class="llm-skip-banner">⚠️ 이 날짜는 학습 콘텐츠가 아직 생성되지 않았습니다 (' + esc(card.llm_status) + '). 조문 정보만 표시합니다.</div>';
+  }
   return '<article class="card ' + lawClass + '">'
     + '<div class="card-header">' + badge + groupBadge + catBadge + dateInfo + '</div>'
     + '<div class="jo-label">📖 ' + esc(lawName) + ' 제' + esc(jo) + '조</div>'


### PR DESCRIPTION
## 배경
PR-H5-ε이 누출 감지 시 자동 폴백 활성화했지만, viewer 안내 메시지가 일반 메시지 그대로:
- ⚠️ "이 날짜는 학습 콘텐츠가 아직 생성되지 않았습니다 (skip_external_keywords_leaked)"
- 사실 부정확 — 생성은 됐는데 안전상 차단된 것
- 내부 상태명(`skip_external_keywords_leaked`) 사용자 노출

## 수정 (renderMainCard 분기 추가)
누출 폴백 전용 메시지:
> 🛡️ 안전 모드 — 자동 콘텐츠 검증에서 이 조문에 없는 다른 조문 키워드(음주측정거부)가 감지되어 조문 원문만 표시합니다. (잘못된 학습 콘텐츠 노출 방지)

- 누출 주제(`verification.external_keywords_leaked`) 표시
- 파란 톤(`#eff6ff`)으로 차별화 — '실패'가 아니라 '안전 차단'임을 시각화
- 다른 skip 상태(call_failed·verification_failed)는 기존 노란 경고 그대로

## Test plan
- [ ] 머지 후 누출 케이스 발견 시 viewer에 새 안전 모드 배너 정상 표시
- [ ] 깨끗한 카드는 기존 그대로 (영향 없음)

## 후속 후보
- case_llm.py에도 같은 누출 검증 + 폴백 (PR-H5-η)
- 옛 조문번호 매핑 인덱싱 (근본 해법)

🤖 Generated with [Claude Code](https://claude.com/claude-code)