### PR TITLE
PR-H5-ι: 카드 footer에 verification 상태 배지

### DIFF
--- a/tutor/index.html
+++ b/tutor/index.html
@@ -624,11 +624,26 @@ function renderOtherGroupHistory(card) {
     + '</details>';
 }
 
+// PR-H5-ι: 카드 footer에 verification 상태 배지 — 운영 관찰용 + 안전망 동작 가시화
+function renderVerification(card) {
+  const v = card.verification;
+  if (!v) return '';
+  if (v.status === 'clean') {
+    return '<div style="text-align:center;font-size:11px;color:var(--sub);padding:10px 0 4px;opacity:0.7">🛡️ 콘텐츠 검증 정상</div>';
+  }
+  if (v.status === 'external_keywords_detected') {
+    const themes = (v.external_keywords_leaked || []).join('·');
+    return '<div style="text-align:center;font-size:11px;color:#92400e;padding:10px 0 4px">⚠️ 외부 키워드 감지'
+      + (themes ? ' (' + esc(themes) + ')' : '') + ' — 안전 모드 적용</div>';
+  }
+  return '';
+}
+
 function renderCard(card) {
   // Phase 2: case 카드는 별도 렌더링. card_type 없으면 article 폴백.
   if (card && card.card_type === 'case') return renderCaseCard(card);
   // 순서(R9): 메인 → 조문 원문 → 법리분석 → 학습포인트
-  //          → 관련판례 → 핵심쟁점 → 참고자료 → 법령본문보기
+  //          → 관련판례 → 핵심쟁점 → 참고자료 → 법령본문보기 → verification 배지
   // Phase 3 PR-D — content_tier='simple' (다른 그룹 단순 카드)는 도교법 풀 콘텐츠용 섹션 차단 (자료 없음).
   // PR-F — 단순 카드에도 history_evolution은 추가 (article_history_{group}.json 자료 기반).
   const lc = card.learning_content || {};
@@ -644,7 +659,8 @@ function renderCard(card) {
     isFull ? renderIssues(lc) : '',
     isFull ? renderRefs(card) : '',
     isSimple ? renderOtherGroupHistory(card) : '',
-    renderViewLaw(card)
+    renderViewLaw(card),
+    renderVerification(card)
   ].join('');
 }
 


### PR DESCRIPTION
## 배경
δ로 모든 카드에 `card.verification` 메타 박힘. viewer는 ζ로 폴백 카드만 안내. clean 카드의 검증 상태도 운영 관찰에 도움.

## 수정
- `renderVerification(card)` 함수 신설
  - `clean`: 🛡️ 콘텐츠 검증 정상 (회색·opacity 0.7, 학습 방해 X)
  - `external_keywords_detected`: ⚠️ 외부 키워드 감지 + 누출 주제 표시
- `renderCard()` 마지막 컴포넌트로 추가
- card.verification 없는 구버전 카드 미표시 (호환)

## Test plan
- [ ] 머지 후 viewer에서 오늘 카드 끝에 🛡️ 배지 표시 확인
- [ ] 다음 누출 케이스 발견 시 ⚠️ 배지 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)