### PR TITLE
PR-H6: viewer 로딩 인디케이터 + 구독 상태 깜빡임 fix

### DIFF
--- a/generate_viewer.py
+++ b/generate_viewer.py
@@ -433,9 +433,12 @@ def main():
         alarm_modal = ""
     # 좌측 액션 래퍼 — 알람(road) + 튜터 + 알림받기 셋 다 한 flex 그룹으로 묶음
     # (이전: pushBtn이 우측 absolute라 헤더 통계와 충돌. 사용자 보고 2026-05-27 → 좌측 그룹화)
+    # PR-H6: pushBtn 직후 인라인 스크립트로 localStorage 즉시 적용 — viewer 간 이동 시 깜빡임 차단
     push_button = (
         '<button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">'
         '🔔 알림 받기</button>'
+        '<script>try{if(localStorage.getItem("pushSubscription")){'
+        'document.getElementById("pushBtn").textContent="🔔 구독 중";}}catch(e){}</script>'
     )
     left_actions = f'<div class="header-left-actions">{alarm_button}{tutor_button}{push_button}</div>'
     # 튜터 페이지 본인이면 자기 자신으로 가는 버튼 의미 없음 — 하지만 viewer는 튜터가 아니므로 항상 표시
@@ -723,6 +726,26 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 </head>
 <body>
 
+<!-- PR-H6: 데이터 로딩 인디케이터 — data_core.js (~35MB) 다운로드·파싱 동안 빈 화면 회피 -->
+<div id="loadingOverlay" style="position:fixed;top:0;left:0;width:100%;height:100%;background:linear-gradient(135deg,#1e3a5f 0%,#2c4f7a 100%);color:#fff;display:flex;align-items:center;justify-content:center;z-index:99999;font-family:'Noto Sans KR',sans-serif">
+  <div style="text-align:center;padding:20px">
+    <div style="font-size:48px;margin-bottom:16px">📚</div>
+    <div style="font-size:18px;font-weight:600;margin-bottom:8px">{{LAW_TITLE}} 한눈에</div>
+    <div style="font-size:14px;opacity:0.85">법령 자료 로딩 중...</div>
+    <div style="font-size:11px;opacity:0.6;margin-top:12px">첫 진입은 약 5~10초 소요됩니다<br>(다음 진입부터 브라우저 캐시로 빠름)</div>
+    <div style="margin-top:20px;width:200px;height:3px;background:rgba(255,255,255,0.2);border-radius:2px;overflow:hidden">
+      <div style="height:100%;background:rgba(255,255,255,0.7);animation:loading-bar 1.5s ease-in-out infinite"></div>
+    </div>
+  </div>
+</div>
+<style>
+@keyframes loading-bar {
+  0% { transform: translateX(-100%); width:30%; }
+  50% { width:60%; }
+  100% { transform: translateX(330%); width:30%; }
+}
+</style>
+
 <div class="header" style="position:relative">
   <div class="header-stats" id="headerStats"></div>
   {{ALARM_BUTTON}}<!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
@@ -841,6 +864,8 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
 <script src="web_data/data_core.js"></script>
+<!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
+<script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;

--- a/tutor/index.html
+++ b/tutor/index.html
@@ -225,7 +225,9 @@ footer a { color: var(--sub); text-decoration: underline; }
     <p style="margin:0;font-size:13px;line-height:1.5;opacity:0.92">매일 한 건 — 도로교통법 현행 + 해설 + 판례 통합 학습 — <a href="../viewer.html">📖 도로교통법 통합 조회</a></p>
   </div>
   <!-- PR-H2 — 알림 구독 UI (헤더 우측 flex 배치, 모바일 wrap 대응) -->
+  <!-- PR-H6: pushBtn 직후 인라인 스크립트 — localStorage 즉시 적용으로 viewer↔tutor 이동 시 깜빡임 차단 -->
   <button id="pushBtn" onclick="subscribePush()" style="flex-shrink:0;padding:8px 12px;border:1px solid var(--border);background:#fff;border-radius:8px;cursor:pointer;font-size:13px;color:var(--law);font-weight:600;white-space:nowrap">🔔 알림 받기</button>
+  <script>try{if(localStorage.getItem("pushSubscription")){document.getElementById("pushBtn").textContent="🔔 구독 중";}}catch(e){}</script>
 </header>
 
 <!-- PR-H2 — 구독 결과 모달 -->

--- a/viewer.html
+++ b/viewer.html
@@ -238,9 +238,29 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 </head>
 <body>
 
+<!-- PR-H6: 데이터 로딩 인디케이터 — data_core.js (~35MB) 다운로드·파싱 동안 빈 화면 회피 -->
+<div id="loadingOverlay" style="position:fixed;top:0;left:0;width:100%;height:100%;background:linear-gradient(135deg,#1e3a5f 0%,#2c4f7a 100%);color:#fff;display:flex;align-items:center;justify-content:center;z-index:99999;font-family:'Noto Sans KR',sans-serif">
+  <div style="text-align:center;padding:20px">
+    <div style="font-size:48px;margin-bottom:16px">📚</div>
+    <div style="font-size:18px;font-weight:600;margin-bottom:8px">도로교통법 한눈에</div>
+    <div style="font-size:14px;opacity:0.85">법령 자료 로딩 중...</div>
+    <div style="font-size:11px;opacity:0.6;margin-top:12px">첫 진입은 약 5~10초 소요됩니다<br>(다음 진입부터 브라우저 캐시로 빠름)</div>
+    <div style="margin-top:20px;width:200px;height:3px;background:rgba(255,255,255,0.2);border-radius:2px;overflow:hidden">
+      <div style="height:100%;background:rgba(255,255,255,0.7);animation:loading-bar 1.5s ease-in-out infinite"></div>
+    </div>
+  </div>
+</div>
+<style>
+@keyframes loading-bar {
+  0% { transform: translateX(-100%); width:30%; }
+  50% { width:60%; }
+  100% { transform: translateX(330%); width:30%; }
+}
+</style>
+
 <div class="header" style="position:relative">
   <div class="header-stats" id="headerStats"></div>
-  <div class="header-left-actions"><button type="button" class="header-action-btn alarm header-alarm-link" id="alarmLink" onclick="openAlarmModal()">📢 최근 개정 알림</button><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
+  <div class="header-left-actions"><button type="button" class="header-action-btn alarm header-alarm-link" id="alarmLink" onclick="openAlarmModal()">📢 최근 개정 알림</button><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button><script>try{if(localStorage.getItem("pushSubscription")){document.getElementById("pushBtn").textContent="🔔 구독 중";}}catch(e){}</script></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
   <h1>도로교통법 한눈에</h1>
   <p>법률 · 시행령 · 시행규칙 · 별표 통합 비교</p>
 </div>
@@ -356,7 +376,9 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core.js?v=20260527004042"></script>
+<script src="web_data/data_core.js?v=20260527204116"></script>
+<!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
+<script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -369,7 +391,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527004042';
+const _LAZY_TS = '20260527204116';
 const _LAZY_SFX = '';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_car_mgmt.html
+++ b/viewer_car_mgmt.html
@@ -238,9 +238,29 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 </head>
 <body>
 
+<!-- PR-H6: 데이터 로딩 인디케이터 — data_core.js (~35MB) 다운로드·파싱 동안 빈 화면 회피 -->
+<div id="loadingOverlay" style="position:fixed;top:0;left:0;width:100%;height:100%;background:linear-gradient(135deg,#1e3a5f 0%,#2c4f7a 100%);color:#fff;display:flex;align-items:center;justify-content:center;z-index:99999;font-family:'Noto Sans KR',sans-serif">
+  <div style="text-align:center;padding:20px">
+    <div style="font-size:48px;margin-bottom:16px">📚</div>
+    <div style="font-size:18px;font-weight:600;margin-bottom:8px">자동차관리법 한눈에</div>
+    <div style="font-size:14px;opacity:0.85">법령 자료 로딩 중...</div>
+    <div style="font-size:11px;opacity:0.6;margin-top:12px">첫 진입은 약 5~10초 소요됩니다<br>(다음 진입부터 브라우저 캐시로 빠름)</div>
+    <div style="margin-top:20px;width:200px;height:3px;background:rgba(255,255,255,0.2);border-radius:2px;overflow:hidden">
+      <div style="height:100%;background:rgba(255,255,255,0.7);animation:loading-bar 1.5s ease-in-out infinite"></div>
+    </div>
+  </div>
+</div>
+<style>
+@keyframes loading-bar {
+  0% { transform: translateX(-100%); width:30%; }
+  50% { width:60%; }
+  100% { transform: translateX(330%); width:30%; }
+}
+</style>
+
 <div class="header" style="position:relative">
   <div class="header-stats" id="headerStats"></div>
-  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
+  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button><script>try{if(localStorage.getItem("pushSubscription")){document.getElementById("pushBtn").textContent="🔔 구독 중";}}catch(e){}</script></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
   <h1>자동차관리법 한눈에</h1>
   <p>법률 · 시행령 · 시행규칙 · 별표 통합 비교</p>
 </div>
@@ -355,7 +375,9 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_car_mgmt.js?v=20260527004045"></script>
+<script src="web_data/data_core_car_mgmt.js?v=20260527204121"></script>
+<!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
+<script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -368,7 +390,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527004045';
+const _LAZY_TS = '20260527204121';
 const _LAZY_SFX = '_car_mgmt';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_cargo_transport.html
+++ b/viewer_cargo_transport.html
@@ -238,9 +238,29 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 </head>
 <body>
 
+<!-- PR-H6: 데이터 로딩 인디케이터 — data_core.js (~35MB) 다운로드·파싱 동안 빈 화면 회피 -->
+<div id="loadingOverlay" style="position:fixed;top:0;left:0;width:100%;height:100%;background:linear-gradient(135deg,#1e3a5f 0%,#2c4f7a 100%);color:#fff;display:flex;align-items:center;justify-content:center;z-index:99999;font-family:'Noto Sans KR',sans-serif">
+  <div style="text-align:center;padding:20px">
+    <div style="font-size:48px;margin-bottom:16px">📚</div>
+    <div style="font-size:18px;font-weight:600;margin-bottom:8px">화물자동차 운수사업법 한눈에</div>
+    <div style="font-size:14px;opacity:0.85">법령 자료 로딩 중...</div>
+    <div style="font-size:11px;opacity:0.6;margin-top:12px">첫 진입은 약 5~10초 소요됩니다<br>(다음 진입부터 브라우저 캐시로 빠름)</div>
+    <div style="margin-top:20px;width:200px;height:3px;background:rgba(255,255,255,0.2);border-radius:2px;overflow:hidden">
+      <div style="height:100%;background:rgba(255,255,255,0.7);animation:loading-bar 1.5s ease-in-out infinite"></div>
+    </div>
+  </div>
+</div>
+<style>
+@keyframes loading-bar {
+  0% { transform: translateX(-100%); width:30%; }
+  50% { width:60%; }
+  100% { transform: translateX(330%); width:30%; }
+}
+</style>
+
 <div class="header" style="position:relative">
   <div class="header-stats" id="headerStats"></div>
-  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
+  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button><script>try{if(localStorage.getItem("pushSubscription")){document.getElementById("pushBtn").textContent="🔔 구독 중";}}catch(e){}</script></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
   <h1>화물자동차 운수사업법 한눈에</h1>
   <p>법률 · 시행령 · 시행규칙 · 별표 통합 비교</p>
 </div>
@@ -355,7 +375,9 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_cargo_transport.js?v=20260527004047"></script>
+<script src="web_data/data_core_cargo_transport.js?v=20260527204125"></script>
+<!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
+<script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -368,7 +390,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527004047';
+const _LAZY_TS = '20260527204125';
 const _LAZY_SFX = '_cargo_transport';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_crim_proc.html
+++ b/viewer_crim_proc.html
@@ -238,9 +238,29 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 </head>
 <body>
 
+<!-- PR-H6: 데이터 로딩 인디케이터 — data_core.js (~35MB) 다운로드·파싱 동안 빈 화면 회피 -->
+<div id="loadingOverlay" style="position:fixed;top:0;left:0;width:100%;height:100%;background:linear-gradient(135deg,#1e3a5f 0%,#2c4f7a 100%);color:#fff;display:flex;align-items:center;justify-content:center;z-index:99999;font-family:'Noto Sans KR',sans-serif">
+  <div style="text-align:center;padding:20px">
+    <div style="font-size:48px;margin-bottom:16px">📚</div>
+    <div style="font-size:18px;font-weight:600;margin-bottom:8px">형사소송법 한눈에</div>
+    <div style="font-size:14px;opacity:0.85">법령 자료 로딩 중...</div>
+    <div style="font-size:11px;opacity:0.6;margin-top:12px">첫 진입은 약 5~10초 소요됩니다<br>(다음 진입부터 브라우저 캐시로 빠름)</div>
+    <div style="margin-top:20px;width:200px;height:3px;background:rgba(255,255,255,0.2);border-radius:2px;overflow:hidden">
+      <div style="height:100%;background:rgba(255,255,255,0.7);animation:loading-bar 1.5s ease-in-out infinite"></div>
+    </div>
+  </div>
+</div>
+<style>
+@keyframes loading-bar {
+  0% { transform: translateX(-100%); width:30%; }
+  50% { width:60%; }
+  100% { transform: translateX(330%); width:30%; }
+}
+</style>
+
 <div class="header" style="position:relative">
   <div class="header-stats" id="headerStats"></div>
-  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
+  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button><script>try{if(localStorage.getItem("pushSubscription")){document.getElementById("pushBtn").textContent="🔔 구독 중";}}catch(e){}</script></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
   <h1>형사소송법 한눈에</h1>
   <p>법률 · 시행령 · 시행규칙 · 별표 통합 비교</p>
 </div>
@@ -355,7 +375,9 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_crim_proc.js?v=20260527004047"></script>
+<script src="web_data/data_core_crim_proc.js?v=20260527204125"></script>
+<!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
+<script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -368,7 +390,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527004047';
+const _LAZY_TS = '20260527204125';
 const _LAZY_SFX = '_crim_proc';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_passenger_transport.html
+++ b/viewer_passenger_transport.html
@@ -238,9 +238,29 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 </head>
 <body>
 
+<!-- PR-H6: 데이터 로딩 인디케이터 — data_core.js (~35MB) 다운로드·파싱 동안 빈 화면 회피 -->
+<div id="loadingOverlay" style="position:fixed;top:0;left:0;width:100%;height:100%;background:linear-gradient(135deg,#1e3a5f 0%,#2c4f7a 100%);color:#fff;display:flex;align-items:center;justify-content:center;z-index:99999;font-family:'Noto Sans KR',sans-serif">
+  <div style="text-align:center;padding:20px">
+    <div style="font-size:48px;margin-bottom:16px">📚</div>
+    <div style="font-size:18px;font-weight:600;margin-bottom:8px">여객자동차 운수사업법 한눈에</div>
+    <div style="font-size:14px;opacity:0.85">법령 자료 로딩 중...</div>
+    <div style="font-size:11px;opacity:0.6;margin-top:12px">첫 진입은 약 5~10초 소요됩니다<br>(다음 진입부터 브라우저 캐시로 빠름)</div>
+    <div style="margin-top:20px;width:200px;height:3px;background:rgba(255,255,255,0.2);border-radius:2px;overflow:hidden">
+      <div style="height:100%;background:rgba(255,255,255,0.7);animation:loading-bar 1.5s ease-in-out infinite"></div>
+    </div>
+  </div>
+</div>
+<style>
+@keyframes loading-bar {
+  0% { transform: translateX(-100%); width:30%; }
+  50% { width:60%; }
+  100% { transform: translateX(330%); width:30%; }
+}
+</style>
+
 <div class="header" style="position:relative">
   <div class="header-stats" id="headerStats"></div>
-  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
+  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button><script>try{if(localStorage.getItem("pushSubscription")){document.getElementById("pushBtn").textContent="🔔 구독 중";}}catch(e){}</script></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
   <h1>여객자동차 운수사업법 한눈에</h1>
   <p>법률 · 시행령 · 시행규칙 · 별표 통합 비교</p>
 </div>
@@ -355,7 +375,9 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_passenger_transport.js?v=20260527004046"></script>
+<script src="web_data/data_core_passenger_transport.js?v=20260527204123"></script>
+<!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
+<script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -368,7 +390,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527004046';
+const _LAZY_TS = '20260527204123';
 const _LAZY_SFX = '_passenger_transport';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_tkga.html
+++ b/viewer_tkga.html
@@ -238,9 +238,29 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 </head>
 <body>
 
+<!-- PR-H6: 데이터 로딩 인디케이터 — data_core.js (~35MB) 다운로드·파싱 동안 빈 화면 회피 -->
+<div id="loadingOverlay" style="position:fixed;top:0;left:0;width:100%;height:100%;background:linear-gradient(135deg,#1e3a5f 0%,#2c4f7a 100%);color:#fff;display:flex;align-items:center;justify-content:center;z-index:99999;font-family:'Noto Sans KR',sans-serif">
+  <div style="text-align:center;padding:20px">
+    <div style="font-size:48px;margin-bottom:16px">📚</div>
+    <div style="font-size:18px;font-weight:600;margin-bottom:8px">특정범죄 가중처벌 등에 관한 법률 한눈에</div>
+    <div style="font-size:14px;opacity:0.85">법령 자료 로딩 중...</div>
+    <div style="font-size:11px;opacity:0.6;margin-top:12px">첫 진입은 약 5~10초 소요됩니다<br>(다음 진입부터 브라우저 캐시로 빠름)</div>
+    <div style="margin-top:20px;width:200px;height:3px;background:rgba(255,255,255,0.2);border-radius:2px;overflow:hidden">
+      <div style="height:100%;background:rgba(255,255,255,0.7);animation:loading-bar 1.5s ease-in-out infinite"></div>
+    </div>
+  </div>
+</div>
+<style>
+@keyframes loading-bar {
+  0% { transform: translateX(-100%); width:30%; }
+  50% { width:60%; }
+  100% { transform: translateX(330%); width:30%; }
+}
+</style>
+
 <div class="header" style="position:relative">
   <div class="header-stats" id="headerStats"></div>
-  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
+  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button><script>try{if(localStorage.getItem("pushSubscription")){document.getElementById("pushBtn").textContent="🔔 구독 중";}}catch(e){}</script></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
   <h1>특정범죄 가중처벌 등에 관한 법률 한눈에</h1>
   <p>법률 · 시행령 · 시행규칙 · 별표 통합 비교</p>
 </div>
@@ -355,7 +375,9 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_tkga.js?v=20260527004043"></script>
+<script src="web_data/data_core_tkga.js?v=20260527204118"></script>
+<!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
+<script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -368,7 +390,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527004043';
+const _LAZY_TS = '20260527204118';
 const _LAZY_SFX = '_tkga';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){

--- a/viewer_tlspc.html
+++ b/viewer_tlspc.html
@@ -238,9 +238,29 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 </head>
 <body>
 
+<!-- PR-H6: 데이터 로딩 인디케이터 — data_core.js (~35MB) 다운로드·파싱 동안 빈 화면 회피 -->
+<div id="loadingOverlay" style="position:fixed;top:0;left:0;width:100%;height:100%;background:linear-gradient(135deg,#1e3a5f 0%,#2c4f7a 100%);color:#fff;display:flex;align-items:center;justify-content:center;z-index:99999;font-family:'Noto Sans KR',sans-serif">
+  <div style="text-align:center;padding:20px">
+    <div style="font-size:48px;margin-bottom:16px">📚</div>
+    <div style="font-size:18px;font-weight:600;margin-bottom:8px">교통사고처리 특례법 한눈에</div>
+    <div style="font-size:14px;opacity:0.85">법령 자료 로딩 중...</div>
+    <div style="font-size:11px;opacity:0.6;margin-top:12px">첫 진입은 약 5~10초 소요됩니다<br>(다음 진입부터 브라우저 캐시로 빠름)</div>
+    <div style="margin-top:20px;width:200px;height:3px;background:rgba(255,255,255,0.2);border-radius:2px;overflow:hidden">
+      <div style="height:100%;background:rgba(255,255,255,0.7);animation:loading-bar 1.5s ease-in-out infinite"></div>
+    </div>
+  </div>
+</div>
+<style>
+@keyframes loading-bar {
+  0% { transform: translateX(-100%); width:30%; }
+  50% { width:60%; }
+  100% { transform: translateX(330%); width:30%; }
+}
+</style>
+
 <div class="header" style="position:relative">
   <div class="header-stats" id="headerStats"></div>
-  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
+  <div class="header-left-actions"><a href="./tutor/" class="header-action-btn tutor" title="출근길 법령튜터로 이동">📚 출근길 튜터</a><button id="pushBtn" type="button" class="header-action-btn push" onclick="subscribePush()">🔔 알림 받기</button><script>try{if(localStorage.getItem("pushSubscription")){document.getElementById("pushBtn").textContent="🔔 구독 중";}}catch(e){}</script></div><!-- left_actions 안에 alarm·tutor·push 셋 다 포함 (PR-H4-β/fix) -->
   <h1>교통사고처리 특례법 한눈에</h1>
   <p>법률 · 시행령 · 시행규칙 · 별표 통합 비교</p>
 </div>
@@ -355,7 +375,9 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_tlspc.js?v=20260527004042"></script>
+<script src="web_data/data_core_tlspc.js?v=20260527204117"></script>
+<!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
+<script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
 // 분리 로드된 데이터를 기존 변수명에 매핑 — 본문(data_core)은 즉시 사용 가능
 const mapData = window._DATA_CORE.mapData;
@@ -368,7 +390,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527004042';
+const _LAZY_TS = '20260527204117';
 const _LAZY_SFX = '_tlspc';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){


### PR DESCRIPTION
## 사용자 보고 2건 (2026-05-27)
1. viewer 진입 시 로딩 속도 느림 — `data_core.js` 35MB 동기 로드가 본질
2. 다른 viewer로 이동 시 `[알림 받기]` → `[구독 중]` 깜빡임 0.3~1초

## Q1-A 로딩 인디케이터 (체감 속도 ↑)
- body 시작 직후 `#loadingOverlay` div — 파란 풀스크린 + 📚 + 진행바 애니메이션
- "법령 자료 로딩 중... 첫 진입은 약 5~10초" 안내
- `data_core.js` 직후 inline script로 즉시 숨김
- 빈 화면 회피 → 사용자가 작동 중임 인지

## Q2 깜빡임 fix
**원인**: HTML에 박힌 "알림 받기" → `window.load` + SW ready + `getSubscription()` 비동기 끝나야 변경

**해법**: pushBtn 다음 inline script로 `localStorage.getItem('pushSubscription')` 즉시 확인 → 캐시 있으면 button.textContent 즉시 변경 (DOM 파싱 완료 시점)

viewer + tutor 양쪽 적용.

## Q3 확인 (별도 작업 불필요)
- PWA scope `./`에서 tutor + viewer 7개 모두 같은 SW 공유
- 한 번 구독 = 모든 페이지 자동 공유
- Q2 fix하면 시각적으로도 일관됨

## Test plan
- [ ] 머지 후 모바일 viewer 진입 → 로딩 화면 표시 (~5초) → 컨텐츠 노출
- [ ] viewer 간 법령 전환 시 알림받기 깜빡임 없음 (이미 구독 중이면 "구독 중" 즉시 표시)
- [ ] tutor↔viewer 이동도 깜빡임 없음

## 후속 옵션
- Q1-B JS minify (35MB → ~12MB)
- Q1-C data_core 본체 분할 (조문 인덱스 + chunk lazy load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)