### PR TITLE
fix: 매주 자동 갱신(update.yml)도 Pages 배포 자동 트리거

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,6 +29,7 @@ on:
 permissions:
   contents: write   # commit·push
   issues: write     # 결과 issue 생성
+  actions: write    # PR-H6: deploy_pages workflow_dispatch 트리거 위해 필요 (github-actions[bot] push가 자동 재trigger 안 되는 정책 우회)
 
 jobs:
   update:
@@ -211,6 +212,15 @@ jobs:
           GitHub Actions 매주 자동 실행 (.github/workflows/update.yml)
           "
           git push origin master
+
+      - name: Pages 배포 트리거 (github-actions[bot] push는 자동 재trigger 안 됨)
+        # PR-H6: PR #50과 동일 — bot push가 deploy_pages 자동 호출 안 되는 GitHub 정책 우회
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run deploy_pages.yml --ref master
+          echo "✅ deploy_pages workflow_dispatch 트리거 완료 — 1~2분 후 Pages 반영"
 
       - name: ✅ 성공 Issue 생성
         if: success() && (steps.changes.outputs.has_changes == 'true' || inputs.force_issue == 'true')


### PR DESCRIPTION
## 사용자 우려
"주 1회 API 호출해서 변경사항 자동 업데이트 자동으로 될 수 있도록 구조설계되어야 해. 확실하지?"

## 확인 결과
이미 `.github/workflows/update.yml` (매주 월 05:00 KST cron) 존재 — `update_all.py` 실행:
- 법령정보센터 API 호출 → 데이터 수집 (`collect_*.py`)
- 인덱스 빌드 (`build_3tier_map`, `build_attached_tables`, etc.)
- **viewer.html + web_data 재생성** (`generate_viewer.py`)
- master commit·push + 회귀 검증 + Issue 알림

**다만 미흡한 1군데**: PR #50과 동일 — `github-actions[bot]` push가 deploy_pages 자동 호출 못 함 → 새 viewer가 Pages 반영 안 됨 가능.

## 수정
PR #50 패턴 적용:
- `permissions`에 `actions: write` 추가
- 자동 commit·push step 다음에 `gh workflow run deploy_pages.yml` step 추가
- `has_changes=true`(실제 변경)에만 트리거

## 효과
**완전 자동화 완성**:
매주 월 05:00 KST → 법령 API 호출 → viewer 재생성 → master push → **Pages 자동 반영** → 사용자 모바일에서 다음 진입 시 새 viewer

## Test plan
- [ ] 머지 후 update.yml 수동 dispatch로 동작 확인
- [ ] 다음 월요일 cron에서 변경 발견 시 deploy_pages 자동 트리거 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)