### PR TITLE
chore: Actions Node.js 24 호환 메이저 버전 업그레이드 (6/2 데드라인)

### DIFF
--- a/.github/workflows/daily_push.yml
+++ b/.github/workflows/daily_push.yml
@@ -16,10 +16,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: 체크아웃
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Python 설정
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -29,7 +29,7 @@ jobs:
           pip install requests
 
       - name: Node 설정 (web-push)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -27,16 +27,16 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: 체크아웃
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Pages 환경 설정
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Artifact 업로드 (전체 repo, .nojekyll 포함)
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: '.'
 
       - name: GitHub Pages 배포
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -40,12 +40,12 @@ jobs:
 
     steps:
       - name: 저장소 체크아웃
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Python 3.11 설정
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -60,7 +60,7 @@ jobs:
       # cache/restore + cache/save로 분리하여 빌드 성공 시 검증 결과 무관하게 캐시 저장 보장.
       - name: data/ 캐시 복원
         id: cache-data
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: data
           key: law-history-data-v2-${{ github.run_id }}
@@ -85,7 +85,7 @@ jobs:
       # 캐시 저장 — 빌드 성공 시 검증 결과 무관하게 저장 (다음 워크플로 풀스캔 회피)
       - name: data/ 캐시 저장
         if: always() && steps.build.outcome == 'success'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: data
           key: law-history-data-v2-${{ github.run_id }}
@@ -224,7 +224,7 @@ jobs:
 
       - name: ✅ 성공 Issue 생성
         if: success() && (steps.changes.outputs.has_changes == 'true' || inputs.force_issue == 'true')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           HAS_CHANGES: ${{ steps.changes.outputs.has_changes }}
           STATS: ${{ steps.changes.outputs.stats }}
@@ -331,7 +331,7 @@ jobs:
 
       - name: ⚠️ 실패 Issue 생성
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const tz = { timeZone: 'Asia/Seoul' };


### PR DESCRIPTION
## 배경
GitHub Actions 경고:
> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## 업그레이드 매트릭스
| 액션 | Before | After |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-python | v5 | v6 |
| actions/setup-node | v4 | v6 |
| actions/configure-pages | v5 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |
| actions/cache/{restore,save} | v4 | v5 |
| actions/github-script | v7 | v9 |

## 변경 파일
- `.github/workflows/daily_push.yml`
- `.github/workflows/deploy_pages.yml`
- `.github/workflows/update.yml`

## Test plan
- [ ] 머지 직후 deploy_pages 자동 트리거 → 신버전 액션 정상 동작 확인
- [ ] daily_push.yml workflow_dispatch로 사전 검증 (또는 다음 cron)
- [ ] update.yml workflow_dispatch로 사전 검증 권장 (긴 워크플로)

🤖 Generated with [Claude Code](https://claude.com/claude-code)