### PR TITLE
PR-H7: 모달 X 닫기 fix + tutor 헤더 통합 조회 베너화

### DIFF
--- a/generate_viewer.py
+++ b/generate_viewer.py
@@ -2810,7 +2810,14 @@ function lcsLines(a,b){
 
 function escPlain(s){return(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')}
 
-function closeModal(){document.getElementById('modalOverlay').classList.remove('open')}
+function closeModal(){
+  // PR-H7-fix: lazy 가드가 inline style.display='flex'로 모달 열어둔 경우도 정리
+  // (classList.remove만 하면 inline style 남아 X 클릭이 무시되던 문제)
+  const el = document.getElementById('modalOverlay');
+  if (!el) return;
+  el.classList.remove('open');
+  el.style.display = '';
+}
 
 // 내부 조문 인용 클릭 시 — 모달로 미리보기 (원래 화면 유지). 더 깊이 보려면 "이 조문 화면으로 이동" 버튼.
 // F11(2026-05-22): lawType 인자 추가 — 시행령·시행규칙 본문의 자기참조 "제X조"도 자기법 모달로 표시

--- a/tutor/index.html
+++ b/tutor/index.html
@@ -222,11 +222,14 @@ footer a { color: var(--sub); text-decoration: underline; }
 <header style="display:flex;align-items:flex-start;justify-content:space-between;gap:10px;flex-wrap:wrap">
   <div style="flex:1;min-width:0">
     <h1 style="margin:0 0 4px;font-size:22px">📚 출근길 법령 튜터</h1>
-    <p style="margin:0;font-size:13px;line-height:1.5;opacity:0.92">매일 한 건 — 도로교통법 현행 + 해설 + 판례 통합 학습 — <a href="../viewer.html">📖 도로교통법 통합 조회</a></p>
+    <p style="margin:0;font-size:13px;line-height:1.5;opacity:0.92">매일 한 건 — 도로교통법 현행 + 해설 + 판례 통합 학습</p>
   </div>
-  <!-- PR-H2 — 알림 구독 UI (헤더 우측 flex 배치, 모바일 wrap 대응) -->
-  <!-- PR-H6: pushBtn 직후 인라인 스크립트 — localStorage 즉시 적용으로 viewer↔tutor 이동 시 깜빡임 차단 -->
-  <button id="pushBtn" onclick="subscribePush()" style="flex-shrink:0;padding:8px 12px;border:1px solid var(--border);background:#fff;border-radius:8px;cursor:pointer;font-size:13px;color:var(--law);font-weight:600;white-space:nowrap">🔔 알림 받기</button>
+  <!-- PR-H7: 통합 조회 베너 + 구독 베너 한 그룹으로 (모바일 wrap 대응) -->
+  <!-- localStorage 즉시 적용으로 viewer↔tutor 이동 시 깜빡임 차단 (PR-H6) -->
+  <div style="display:flex;gap:6px;flex-shrink:0;flex-wrap:wrap">
+    <a href="../viewer.html" style="padding:8px 12px;border:1px solid var(--border);background:#fff;border-radius:8px;font-size:13px;color:var(--law);font-weight:600;white-space:nowrap;text-decoration:none;display:inline-flex;align-items:center;gap:4px">📖 도로교통법 통합 조회</a>
+    <button id="pushBtn" onclick="subscribePush()" style="padding:8px 12px;border:1px solid var(--border);background:#fff;border-radius:8px;cursor:pointer;font-size:13px;color:var(--law);font-weight:600;white-space:nowrap">🔔 알림 받기</button>
+  </div>
   <script>try{if(localStorage.getItem("pushSubscription")){document.getElementById("pushBtn").textContent="🔔 구독 중";}}catch(e){}</script>
 </header>
 

--- a/viewer.html
+++ b/viewer.html
@@ -378,7 +378,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core.js?v=20260527205710"></script>
+<script src="web_data/data_core.js?v=20260527211854"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -393,7 +393,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527205710';
+const _LAZY_TS = '20260527211854';
 const _LAZY_SFX = '';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -2313,7 +2313,14 @@ function lcsLines(a,b){
 
 function escPlain(s){return(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')}
 
-function closeModal(){document.getElementById('modalOverlay').classList.remove('open')}
+function closeModal(){
+  // PR-H7-fix: lazy 가드가 inline style.display='flex'로 모달 열어둔 경우도 정리
+  // (classList.remove만 하면 inline style 남아 X 클릭이 무시되던 문제)
+  const el = document.getElementById('modalOverlay');
+  if (!el) return;
+  el.classList.remove('open');
+  el.style.display = '';
+}
 
 // 내부 조문 인용 클릭 시 — 모달로 미리보기 (원래 화면 유지). 더 깊이 보려면 "이 조문 화면으로 이동" 버튼.
 // F11(2026-05-22): lawType 인자 추가 — 시행령·시행규칙 본문의 자기참조 "제X조"도 자기법 모달로 표시

--- a/viewer_car_mgmt.html
+++ b/viewer_car_mgmt.html
@@ -377,7 +377,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_car_mgmt.js?v=20260527205715"></script>
+<script src="web_data/data_core_car_mgmt.js?v=20260527211859"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -392,7 +392,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527205715';
+const _LAZY_TS = '20260527211859';
 const _LAZY_SFX = '_car_mgmt';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -2312,7 +2312,14 @@ function lcsLines(a,b){
 
 function escPlain(s){return(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')}
 
-function closeModal(){document.getElementById('modalOverlay').classList.remove('open')}
+function closeModal(){
+  // PR-H7-fix: lazy 가드가 inline style.display='flex'로 모달 열어둔 경우도 정리
+  // (classList.remove만 하면 inline style 남아 X 클릭이 무시되던 문제)
+  const el = document.getElementById('modalOverlay');
+  if (!el) return;
+  el.classList.remove('open');
+  el.style.display = '';
+}
 
 // 내부 조문 인용 클릭 시 — 모달로 미리보기 (원래 화면 유지). 더 깊이 보려면 "이 조문 화면으로 이동" 버튼.
 // F11(2026-05-22): lawType 인자 추가 — 시행령·시행규칙 본문의 자기참조 "제X조"도 자기법 모달로 표시

--- a/viewer_cargo_transport.html
+++ b/viewer_cargo_transport.html
@@ -377,7 +377,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_cargo_transport.js?v=20260527205718"></script>
+<script src="web_data/data_core_cargo_transport.js?v=20260527211902"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -392,7 +392,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527205718';
+const _LAZY_TS = '20260527211902';
 const _LAZY_SFX = '_cargo_transport';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -2312,7 +2312,14 @@ function lcsLines(a,b){
 
 function escPlain(s){return(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')}
 
-function closeModal(){document.getElementById('modalOverlay').classList.remove('open')}
+function closeModal(){
+  // PR-H7-fix: lazy 가드가 inline style.display='flex'로 모달 열어둔 경우도 정리
+  // (classList.remove만 하면 inline style 남아 X 클릭이 무시되던 문제)
+  const el = document.getElementById('modalOverlay');
+  if (!el) return;
+  el.classList.remove('open');
+  el.style.display = '';
+}
 
 // 내부 조문 인용 클릭 시 — 모달로 미리보기 (원래 화면 유지). 더 깊이 보려면 "이 조문 화면으로 이동" 버튼.
 // F11(2026-05-22): lawType 인자 추가 — 시행령·시행규칙 본문의 자기참조 "제X조"도 자기법 모달로 표시

--- a/viewer_crim_proc.html
+++ b/viewer_crim_proc.html
@@ -377,7 +377,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_crim_proc.js?v=20260527205718"></script>
+<script src="web_data/data_core_crim_proc.js?v=20260527211902"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -392,7 +392,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527205718';
+const _LAZY_TS = '20260527211902';
 const _LAZY_SFX = '_crim_proc';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -2312,7 +2312,14 @@ function lcsLines(a,b){
 
 function escPlain(s){return(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')}
 
-function closeModal(){document.getElementById('modalOverlay').classList.remove('open')}
+function closeModal(){
+  // PR-H7-fix: lazy 가드가 inline style.display='flex'로 모달 열어둔 경우도 정리
+  // (classList.remove만 하면 inline style 남아 X 클릭이 무시되던 문제)
+  const el = document.getElementById('modalOverlay');
+  if (!el) return;
+  el.classList.remove('open');
+  el.style.display = '';
+}
 
 // 내부 조문 인용 클릭 시 — 모달로 미리보기 (원래 화면 유지). 더 깊이 보려면 "이 조문 화면으로 이동" 버튼.
 // F11(2026-05-22): lawType 인자 추가 — 시행령·시행규칙 본문의 자기참조 "제X조"도 자기법 모달로 표시

--- a/viewer_passenger_transport.html
+++ b/viewer_passenger_transport.html
@@ -377,7 +377,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_passenger_transport.js?v=20260527205717"></script>
+<script src="web_data/data_core_passenger_transport.js?v=20260527211900"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -392,7 +392,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527205717';
+const _LAZY_TS = '20260527211900';
 const _LAZY_SFX = '_passenger_transport';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -2312,7 +2312,14 @@ function lcsLines(a,b){
 
 function escPlain(s){return(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')}
 
-function closeModal(){document.getElementById('modalOverlay').classList.remove('open')}
+function closeModal(){
+  // PR-H7-fix: lazy 가드가 inline style.display='flex'로 모달 열어둔 경우도 정리
+  // (classList.remove만 하면 inline style 남아 X 클릭이 무시되던 문제)
+  const el = document.getElementById('modalOverlay');
+  if (!el) return;
+  el.classList.remove('open');
+  el.style.display = '';
+}
 
 // 내부 조문 인용 클릭 시 — 모달로 미리보기 (원래 화면 유지). 더 깊이 보려면 "이 조문 화면으로 이동" 버튼.
 // F11(2026-05-22): lawType 인자 추가 — 시행령·시행규칙 본문의 자기참조 "제X조"도 자기법 모달로 표시

--- a/viewer_tkga.html
+++ b/viewer_tkga.html
@@ -377,7 +377,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_tkga.js?v=20260527205712"></script>
+<script src="web_data/data_core_tkga.js?v=20260527211856"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -392,7 +392,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527205712';
+const _LAZY_TS = '20260527211856';
 const _LAZY_SFX = '_tkga';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -2312,7 +2312,14 @@ function lcsLines(a,b){
 
 function escPlain(s){return(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')}
 
-function closeModal(){document.getElementById('modalOverlay').classList.remove('open')}
+function closeModal(){
+  // PR-H7-fix: lazy 가드가 inline style.display='flex'로 모달 열어둔 경우도 정리
+  // (classList.remove만 하면 inline style 남아 X 클릭이 무시되던 문제)
+  const el = document.getElementById('modalOverlay');
+  if (!el) return;
+  el.classList.remove('open');
+  el.style.display = '';
+}
 
 // 내부 조문 인용 클릭 시 — 모달로 미리보기 (원래 화면 유지). 더 깊이 보려면 "이 조문 화면으로 이동" 버튼.
 // F11(2026-05-22): lawType 인자 추가 — 시행령·시행규칙 본문의 자기참조 "제X조"도 자기법 모달로 표시

--- a/viewer_tlspc.html
+++ b/viewer_tlspc.html
@@ -377,7 +377,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_tlspc.js?v=20260527205711"></script>
+<script src="web_data/data_core_tlspc.js?v=20260527211855"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -392,7 +392,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527205711';
+const _LAZY_TS = '20260527211855';
 const _LAZY_SFX = '_tlspc';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -2312,7 +2312,14 @@ function lcsLines(a,b){
 
 function escPlain(s){return(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')}
 
-function closeModal(){document.getElementById('modalOverlay').classList.remove('open')}
+function closeModal(){
+  // PR-H7-fix: lazy 가드가 inline style.display='flex'로 모달 열어둔 경우도 정리
+  // (classList.remove만 하면 inline style 남아 X 클릭이 무시되던 문제)
+  const el = document.getElementById('modalOverlay');
+  if (!el) return;
+  el.classList.remove('open');
+  el.style.display = '';
+}
 
 // 내부 조문 인용 클릭 시 — 모달로 미리보기 (원래 화면 유지). 더 깊이 보려면 "이 조문 화면으로 이동" 버튼.
 // F11(2026-05-22): lawType 인자 추가 — 시행령·시행규칙 본문의 자기참조 "제X조"도 자기법 모달로 표시


### PR DESCRIPTION
## 사용자 보고 2건 (2026-05-27)

### Fix 1 — 모달 X 닫기 안 됨
별표/별지 처음 로딩(lazy load) 후 팝업 X 클릭해도 안 닫힘.

**원인**:
- 정상 모달: `classList.add('open')` / `remove('open')` 토글
- 그러나 lazy 가드(`openTable`)는 `overlay.style.display='flex'`로 **inline style** 직접 set
- `closeModal()`은 `classList.remove('open')`만 함 → inline style 잔존 → 안 닫힘

**수정**: closeModal에서 `el.style.display=''`도 함께 정리

### Fix 2 — tutor 헤더 통합 조회 베너화
사용자 요청: 텍스트 링크 형태 → 베너 버튼 + 구독 버튼 옆 배치

이전:
> 매일 한 건 — 도로교통법 현행 + ... — [📖 도로교통법 통합 조회](텍스트)

변경:
> 매일 한 건 — 도로교통법 현행 + 해설 + 판례 통합 학습
> `[📖 도로교통법 통합 조회]` `[🔔 구독 중]`

UI 일관성 — viewer 헤더 액션 그룹과 동일 톤.

## Test plan
- [ ] 별표/별지 모달 로딩 후 X 클릭 시 정상 닫힘
- [ ] tutor 헤더에 두 베너 가지런히 배치 (모바일 wrap 정상)
- [ ] 베너 클릭 시 viewer로 이동
- [ ] 알림받기 / 구독 중 텍스트 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)