### PR TITLE
PR-H7-progress: 별표·연혁 lazy 로딩 진행바·경과시간

### DIFF
--- a/generate_viewer.py
+++ b/generate_viewer.py
@@ -1827,7 +1827,7 @@ function togFull(id,lawType,joKey,hang){
 }
 
 function openTable(lawType,ref){
-  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 모달 스피너 후 데이터 도착 시 재호출
+  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
   if (_lazyTable.status !== 'ready') {
     const overlay=document.getElementById('modalOverlay');
     const titleEl=document.getElementById('modalTitle');
@@ -1838,10 +1838,35 @@ function openTable(lawType,ref){
       if (_lazyTable.status === 'error') {
         bodyEl.innerHTML='<div style="text-align:center;padding:40px;color:#c0392b;font-size:14px">별표 자료를 불러오지 못했습니다.<br><br><button onclick="openTable(\''+lawType+'\',\''+ref+'\')" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div>';
       } else {
-        bodyEl.innerHTML='<div style="text-align:center;padding:60px 20px;color:var(--sub);font-size:14px"><div style="font-size:24px;margin-bottom:12px">⏳</div>별표 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 클릭 시에만 다운로드)</span></div>';
+        // PR-H7: 진행바 + 경과시간 카운터 — 사용자가 동작 확인 가능
+        bodyEl.innerHTML=`
+          <div style="text-align:center;padding:50px 20px;color:var(--law);font-size:14px">
+            <div style="font-size:36px;margin-bottom:14px">📑</div>
+            <div style="font-weight:600;margin-bottom:6px">별표·별지 자료 다운로드 중</div>
+            <div id="lazyElapsed" style="font-size:13px;color:var(--sub);margin-bottom:14px">0초 경과</div>
+            <div style="width:80%;max-width:280px;margin:0 auto;height:6px;background:#e5e3dd;border-radius:3px;overflow:hidden">
+              <div style="height:100%;background:var(--law);animation:lazy-bar 1.4s ease-in-out infinite"></div>
+            </div>
+            <div style="font-size:11px;opacity:.65;margin-top:18px;line-height:1.6">최초 1회만 ~10~20초<br>다음부터는 즉시 표시됩니다</div>
+          </div>
+          <style>@keyframes lazy-bar{0%{transform:translateX(-100%);width:40%}50%{width:70%}100%{transform:translateX(280%);width:40%}}</style>
+        `;
+        // 경과시간 카운터 (1초마다 갱신, lazy ready 시 자동 정리)
+        const startedAt = Date.now();
+        if (window._lazyElapsedTimer) clearInterval(window._lazyElapsedTimer);
+        window._lazyElapsedTimer = setInterval(function(){
+          const el = document.getElementById('lazyElapsed');
+          if (!el) { clearInterval(window._lazyElapsedTimer); return; }
+          el.textContent = Math.floor((Date.now() - startedAt)/1000) + '초 경과';
+        }, 1000);
       }
     }
-    ensureTableExtras().then(function(){ openTable(lawType, ref); }).catch(function(){});
+    ensureTableExtras().then(function(){
+      if (window._lazyElapsedTimer) { clearInterval(window._lazyElapsedTimer); window._lazyElapsedTimer = null; }
+      openTable(lawType, ref);
+    }).catch(function(){
+      if (window._lazyElapsedTimer) { clearInterval(window._lazyElapsedTimer); window._lazyElapsedTimer = null; }
+    });
     return;
   }
   // ref: "별표 16", "별지 제39호서식" 등
@@ -2059,17 +2084,42 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
-  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 historyContent 스피너 후 도착 시 재호출
+  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
   if (_lazyTable.status !== 'ready') {
     const hc = document.getElementById('historyContent');
     if (hc) {
       if (_lazyTable.status === 'error') {
         hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
       } else {
-        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:60px 20px;color:var(--sub)"><div style="font-size:24px;margin-bottom:12px">⏳</div>연혁 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 진입 시에만 다운로드)</span></div></div>';
+        hc.innerHTML = `
+          <div class="main">
+            <div style="text-align:center;padding:60px 20px;color:var(--law)">
+              <div style="font-size:40px;margin-bottom:14px">📜</div>
+              <div style="font-weight:600;font-size:15px;margin-bottom:6px">연혁 자료 다운로드 중</div>
+              <div id="lazyElapsedH" style="font-size:13px;color:var(--sub);margin-bottom:14px">0초 경과</div>
+              <div style="width:80%;max-width:280px;margin:0 auto;height:6px;background:#e5e3dd;border-radius:3px;overflow:hidden">
+                <div style="height:100%;background:var(--law);animation:lazy-bar 1.4s ease-in-out infinite"></div>
+              </div>
+              <div style="font-size:11px;opacity:.65;margin-top:18px;line-height:1.6">최초 1회만 ~10~20초<br>다음부터는 즉시 표시됩니다</div>
+            </div>
+          </div>
+          <style>@keyframes lazy-bar{0%{transform:translateX(-100%);width:40%}50%{width:70%}100%{transform:translateX(280%);width:40%}}</style>
+        `;
+        const startedAt = Date.now();
+        if (window._lazyElapsedTimerH) clearInterval(window._lazyElapsedTimerH);
+        window._lazyElapsedTimerH = setInterval(function(){
+          const el = document.getElementById('lazyElapsedH');
+          if (!el) { clearInterval(window._lazyElapsedTimerH); return; }
+          el.textContent = Math.floor((Date.now() - startedAt)/1000) + '초 경과';
+        }, 1000);
       }
     }
-    ensureTableExtras().then(function(){ renderHistory(); }).catch(function(){});
+    ensureTableExtras().then(function(){
+      if (window._lazyElapsedTimerH) { clearInterval(window._lazyElapsedTimerH); window._lazyElapsedTimerH = null; }
+      renderHistory();
+    }).catch(function(){
+      if (window._lazyElapsedTimerH) { clearInterval(window._lazyElapsedTimerH); window._lazyElapsedTimerH = null; }
+    });
     return;
   }
   // Phase 3 S3-1-b-4-b: 시행령·시행규칙 직접 진입 시 단순 diff 연혁

--- a/viewer.html
+++ b/viewer.html
@@ -378,7 +378,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core.js?v=20260527211854"></script>
+<script src="web_data/data_core.js?v=20260527212738"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -393,7 +393,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527211854';
+const _LAZY_TS = '20260527212738';
 const _LAZY_SFX = '';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -1330,7 +1330,7 @@ function togFull(id,lawType,joKey,hang){
 }
 
 function openTable(lawType,ref){
-  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 모달 스피너 후 데이터 도착 시 재호출
+  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
   if (_lazyTable.status !== 'ready') {
     const overlay=document.getElementById('modalOverlay');
     const titleEl=document.getElementById('modalTitle');
@@ -1341,10 +1341,35 @@ function openTable(lawType,ref){
       if (_lazyTable.status === 'error') {
         bodyEl.innerHTML='<div style="text-align:center;padding:40px;color:#c0392b;font-size:14px">별표 자료를 불러오지 못했습니다.<br><br><button onclick="openTable(\''+lawType+'\',\''+ref+'\')" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div>';
       } else {
-        bodyEl.innerHTML='<div style="text-align:center;padding:60px 20px;color:var(--sub);font-size:14px"><div style="font-size:24px;margin-bottom:12px">⏳</div>별표 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 클릭 시에만 다운로드)</span></div>';
+        // PR-H7: 진행바 + 경과시간 카운터 — 사용자가 동작 확인 가능
+        bodyEl.innerHTML=`
+          <div style="text-align:center;padding:50px 20px;color:var(--law);font-size:14px">
+            <div style="font-size:36px;margin-bottom:14px">📑</div>
+            <div style="font-weight:600;margin-bottom:6px">별표·별지 자료 다운로드 중</div>
+            <div id="lazyElapsed" style="font-size:13px;color:var(--sub);margin-bottom:14px">0초 경과</div>
+            <div style="width:80%;max-width:280px;margin:0 auto;height:6px;background:#e5e3dd;border-radius:3px;overflow:hidden">
+              <div style="height:100%;background:var(--law);animation:lazy-bar 1.4s ease-in-out infinite"></div>
+            </div>
+            <div style="font-size:11px;opacity:.65;margin-top:18px;line-height:1.6">최초 1회만 ~10~20초<br>다음부터는 즉시 표시됩니다</div>
+          </div>
+          <style>@keyframes lazy-bar{0%{transform:translateX(-100%);width:40%}50%{width:70%}100%{transform:translateX(280%);width:40%}}</style>
+        `;
+        // 경과시간 카운터 (1초마다 갱신, lazy ready 시 자동 정리)
+        const startedAt = Date.now();
+        if (window._lazyElapsedTimer) clearInterval(window._lazyElapsedTimer);
+        window._lazyElapsedTimer = setInterval(function(){
+          const el = document.getElementById('lazyElapsed');
+          if (!el) { clearInterval(window._lazyElapsedTimer); return; }
+          el.textContent = Math.floor((Date.now() - startedAt)/1000) + '초 경과';
+        }, 1000);
       }
     }
-    ensureTableExtras().then(function(){ openTable(lawType, ref); }).catch(function(){});
+    ensureTableExtras().then(function(){
+      if (window._lazyElapsedTimer) { clearInterval(window._lazyElapsedTimer); window._lazyElapsedTimer = null; }
+      openTable(lawType, ref);
+    }).catch(function(){
+      if (window._lazyElapsedTimer) { clearInterval(window._lazyElapsedTimer); window._lazyElapsedTimer = null; }
+    });
     return;
   }
   // ref: "별표 16", "별지 제39호서식" 등
@@ -1562,17 +1587,42 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
-  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 historyContent 스피너 후 도착 시 재호출
+  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
   if (_lazyTable.status !== 'ready') {
     const hc = document.getElementById('historyContent');
     if (hc) {
       if (_lazyTable.status === 'error') {
         hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
       } else {
-        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:60px 20px;color:var(--sub)"><div style="font-size:24px;margin-bottom:12px">⏳</div>연혁 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 진입 시에만 다운로드)</span></div></div>';
+        hc.innerHTML = `
+          <div class="main">
+            <div style="text-align:center;padding:60px 20px;color:var(--law)">
+              <div style="font-size:40px;margin-bottom:14px">📜</div>
+              <div style="font-weight:600;font-size:15px;margin-bottom:6px">연혁 자료 다운로드 중</div>
+              <div id="lazyElapsedH" style="font-size:13px;color:var(--sub);margin-bottom:14px">0초 경과</div>
+              <div style="width:80%;max-width:280px;margin:0 auto;height:6px;background:#e5e3dd;border-radius:3px;overflow:hidden">
+                <div style="height:100%;background:var(--law);animation:lazy-bar 1.4s ease-in-out infinite"></div>
+              </div>
+              <div style="font-size:11px;opacity:.65;margin-top:18px;line-height:1.6">최초 1회만 ~10~20초<br>다음부터는 즉시 표시됩니다</div>
+            </div>
+          </div>
+          <style>@keyframes lazy-bar{0%{transform:translateX(-100%);width:40%}50%{width:70%}100%{transform:translateX(280%);width:40%}}</style>
+        `;
+        const startedAt = Date.now();
+        if (window._lazyElapsedTimerH) clearInterval(window._lazyElapsedTimerH);
+        window._lazyElapsedTimerH = setInterval(function(){
+          const el = document.getElementById('lazyElapsedH');
+          if (!el) { clearInterval(window._lazyElapsedTimerH); return; }
+          el.textContent = Math.floor((Date.now() - startedAt)/1000) + '초 경과';
+        }, 1000);
       }
     }
-    ensureTableExtras().then(function(){ renderHistory(); }).catch(function(){});
+    ensureTableExtras().then(function(){
+      if (window._lazyElapsedTimerH) { clearInterval(window._lazyElapsedTimerH); window._lazyElapsedTimerH = null; }
+      renderHistory();
+    }).catch(function(){
+      if (window._lazyElapsedTimerH) { clearInterval(window._lazyElapsedTimerH); window._lazyElapsedTimerH = null; }
+    });
     return;
   }
   // Phase 3 S3-1-b-4-b: 시행령·시행규칙 직접 진입 시 단순 diff 연혁

--- a/viewer_car_mgmt.html
+++ b/viewer_car_mgmt.html
@@ -377,7 +377,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_car_mgmt.js?v=20260527211859"></script>
+<script src="web_data/data_core_car_mgmt.js?v=20260527212742"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -392,7 +392,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527211859';
+const _LAZY_TS = '20260527212742';
 const _LAZY_SFX = '_car_mgmt';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -1329,7 +1329,7 @@ function togFull(id,lawType,joKey,hang){
 }
 
 function openTable(lawType,ref){
-  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 모달 스피너 후 데이터 도착 시 재호출
+  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
   if (_lazyTable.status !== 'ready') {
     const overlay=document.getElementById('modalOverlay');
     const titleEl=document.getElementById('modalTitle');
@@ -1340,10 +1340,35 @@ function openTable(lawType,ref){
       if (_lazyTable.status === 'error') {
         bodyEl.innerHTML='<div style="text-align:center;padding:40px;color:#c0392b;font-size:14px">별표 자료를 불러오지 못했습니다.<br><br><button onclick="openTable(\''+lawType+'\',\''+ref+'\')" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div>';
       } else {
-        bodyEl.innerHTML='<div style="text-align:center;padding:60px 20px;color:var(--sub);font-size:14px"><div style="font-size:24px;margin-bottom:12px">⏳</div>별표 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 클릭 시에만 다운로드)</span></div>';
+        // PR-H7: 진행바 + 경과시간 카운터 — 사용자가 동작 확인 가능
+        bodyEl.innerHTML=`
+          <div style="text-align:center;padding:50px 20px;color:var(--law);font-size:14px">
+            <div style="font-size:36px;margin-bottom:14px">📑</div>
+            <div style="font-weight:600;margin-bottom:6px">별표·별지 자료 다운로드 중</div>
+            <div id="lazyElapsed" style="font-size:13px;color:var(--sub);margin-bottom:14px">0초 경과</div>
+            <div style="width:80%;max-width:280px;margin:0 auto;height:6px;background:#e5e3dd;border-radius:3px;overflow:hidden">
+              <div style="height:100%;background:var(--law);animation:lazy-bar 1.4s ease-in-out infinite"></div>
+            </div>
+            <div style="font-size:11px;opacity:.65;margin-top:18px;line-height:1.6">최초 1회만 ~10~20초<br>다음부터는 즉시 표시됩니다</div>
+          </div>
+          <style>@keyframes lazy-bar{0%{transform:translateX(-100%);width:40%}50%{width:70%}100%{transform:translateX(280%);width:40%}}</style>
+        `;
+        // 경과시간 카운터 (1초마다 갱신, lazy ready 시 자동 정리)
+        const startedAt = Date.now();
+        if (window._lazyElapsedTimer) clearInterval(window._lazyElapsedTimer);
+        window._lazyElapsedTimer = setInterval(function(){
+          const el = document.getElementById('lazyElapsed');
+          if (!el) { clearInterval(window._lazyElapsedTimer); return; }
+          el.textContent = Math.floor((Date.now() - startedAt)/1000) + '초 경과';
+        }, 1000);
       }
     }
-    ensureTableExtras().then(function(){ openTable(lawType, ref); }).catch(function(){});
+    ensureTableExtras().then(function(){
+      if (window._lazyElapsedTimer) { clearInterval(window._lazyElapsedTimer); window._lazyElapsedTimer = null; }
+      openTable(lawType, ref);
+    }).catch(function(){
+      if (window._lazyElapsedTimer) { clearInterval(window._lazyElapsedTimer); window._lazyElapsedTimer = null; }
+    });
     return;
   }
   // ref: "별표 16", "별지 제39호서식" 등
@@ -1561,17 +1586,42 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
-  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 historyContent 스피너 후 도착 시 재호출
+  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
   if (_lazyTable.status !== 'ready') {
     const hc = document.getElementById('historyContent');
     if (hc) {
       if (_lazyTable.status === 'error') {
         hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
       } else {
-        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:60px 20px;color:var(--sub)"><div style="font-size:24px;margin-bottom:12px">⏳</div>연혁 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 진입 시에만 다운로드)</span></div></div>';
+        hc.innerHTML = `
+          <div class="main">
+            <div style="text-align:center;padding:60px 20px;color:var(--law)">
+              <div style="font-size:40px;margin-bottom:14px">📜</div>
+              <div style="font-weight:600;font-size:15px;margin-bottom:6px">연혁 자료 다운로드 중</div>
+              <div id="lazyElapsedH" style="font-size:13px;color:var(--sub);margin-bottom:14px">0초 경과</div>
+              <div style="width:80%;max-width:280px;margin:0 auto;height:6px;background:#e5e3dd;border-radius:3px;overflow:hidden">
+                <div style="height:100%;background:var(--law);animation:lazy-bar 1.4s ease-in-out infinite"></div>
+              </div>
+              <div style="font-size:11px;opacity:.65;margin-top:18px;line-height:1.6">최초 1회만 ~10~20초<br>다음부터는 즉시 표시됩니다</div>
+            </div>
+          </div>
+          <style>@keyframes lazy-bar{0%{transform:translateX(-100%);width:40%}50%{width:70%}100%{transform:translateX(280%);width:40%}}</style>
+        `;
+        const startedAt = Date.now();
+        if (window._lazyElapsedTimerH) clearInterval(window._lazyElapsedTimerH);
+        window._lazyElapsedTimerH = setInterval(function(){
+          const el = document.getElementById('lazyElapsedH');
+          if (!el) { clearInterval(window._lazyElapsedTimerH); return; }
+          el.textContent = Math.floor((Date.now() - startedAt)/1000) + '초 경과';
+        }, 1000);
       }
     }
-    ensureTableExtras().then(function(){ renderHistory(); }).catch(function(){});
+    ensureTableExtras().then(function(){
+      if (window._lazyElapsedTimerH) { clearInterval(window._lazyElapsedTimerH); window._lazyElapsedTimerH = null; }
+      renderHistory();
+    }).catch(function(){
+      if (window._lazyElapsedTimerH) { clearInterval(window._lazyElapsedTimerH); window._lazyElapsedTimerH = null; }
+    });
     return;
   }
   // Phase 3 S3-1-b-4-b: 시행령·시행규칙 직접 진입 시 단순 diff 연혁

--- a/viewer_cargo_transport.html
+++ b/viewer_cargo_transport.html
@@ -377,7 +377,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_cargo_transport.js?v=20260527211902"></script>
+<script src="web_data/data_core_cargo_transport.js?v=20260527212745"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -392,7 +392,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527211902';
+const _LAZY_TS = '20260527212745';
 const _LAZY_SFX = '_cargo_transport';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -1329,7 +1329,7 @@ function togFull(id,lawType,joKey,hang){
 }
 
 function openTable(lawType,ref){
-  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 모달 스피너 후 데이터 도착 시 재호출
+  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
   if (_lazyTable.status !== 'ready') {
     const overlay=document.getElementById('modalOverlay');
     const titleEl=document.getElementById('modalTitle');
@@ -1340,10 +1340,35 @@ function openTable(lawType,ref){
       if (_lazyTable.status === 'error') {
         bodyEl.innerHTML='<div style="text-align:center;padding:40px;color:#c0392b;font-size:14px">별표 자료를 불러오지 못했습니다.<br><br><button onclick="openTable(\''+lawType+'\',\''+ref+'\')" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div>';
       } else {
-        bodyEl.innerHTML='<div style="text-align:center;padding:60px 20px;color:var(--sub);font-size:14px"><div style="font-size:24px;margin-bottom:12px">⏳</div>별표 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 클릭 시에만 다운로드)</span></div>';
+        // PR-H7: 진행바 + 경과시간 카운터 — 사용자가 동작 확인 가능
+        bodyEl.innerHTML=`
+          <div style="text-align:center;padding:50px 20px;color:var(--law);font-size:14px">
+            <div style="font-size:36px;margin-bottom:14px">📑</div>
+            <div style="font-weight:600;margin-bottom:6px">별표·별지 자료 다운로드 중</div>
+            <div id="lazyElapsed" style="font-size:13px;color:var(--sub);margin-bottom:14px">0초 경과</div>
+            <div style="width:80%;max-width:280px;margin:0 auto;height:6px;background:#e5e3dd;border-radius:3px;overflow:hidden">
+              <div style="height:100%;background:var(--law);animation:lazy-bar 1.4s ease-in-out infinite"></div>
+            </div>
+            <div style="font-size:11px;opacity:.65;margin-top:18px;line-height:1.6">최초 1회만 ~10~20초<br>다음부터는 즉시 표시됩니다</div>
+          </div>
+          <style>@keyframes lazy-bar{0%{transform:translateX(-100%);width:40%}50%{width:70%}100%{transform:translateX(280%);width:40%}}</style>
+        `;
+        // 경과시간 카운터 (1초마다 갱신, lazy ready 시 자동 정리)
+        const startedAt = Date.now();
+        if (window._lazyElapsedTimer) clearInterval(window._lazyElapsedTimer);
+        window._lazyElapsedTimer = setInterval(function(){
+          const el = document.getElementById('lazyElapsed');
+          if (!el) { clearInterval(window._lazyElapsedTimer); return; }
+          el.textContent = Math.floor((Date.now() - startedAt)/1000) + '초 경과';
+        }, 1000);
       }
     }
-    ensureTableExtras().then(function(){ openTable(lawType, ref); }).catch(function(){});
+    ensureTableExtras().then(function(){
+      if (window._lazyElapsedTimer) { clearInterval(window._lazyElapsedTimer); window._lazyElapsedTimer = null; }
+      openTable(lawType, ref);
+    }).catch(function(){
+      if (window._lazyElapsedTimer) { clearInterval(window._lazyElapsedTimer); window._lazyElapsedTimer = null; }
+    });
     return;
   }
   // ref: "별표 16", "별지 제39호서식" 등
@@ -1561,17 +1586,42 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
-  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 historyContent 스피너 후 도착 시 재호출
+  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
   if (_lazyTable.status !== 'ready') {
     const hc = document.getElementById('historyContent');
     if (hc) {
       if (_lazyTable.status === 'error') {
         hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
       } else {
-        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:60px 20px;color:var(--sub)"><div style="font-size:24px;margin-bottom:12px">⏳</div>연혁 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 진입 시에만 다운로드)</span></div></div>';
+        hc.innerHTML = `
+          <div class="main">
+            <div style="text-align:center;padding:60px 20px;color:var(--law)">
+              <div style="font-size:40px;margin-bottom:14px">📜</div>
+              <div style="font-weight:600;font-size:15px;margin-bottom:6px">연혁 자료 다운로드 중</div>
+              <div id="lazyElapsedH" style="font-size:13px;color:var(--sub);margin-bottom:14px">0초 경과</div>
+              <div style="width:80%;max-width:280px;margin:0 auto;height:6px;background:#e5e3dd;border-radius:3px;overflow:hidden">
+                <div style="height:100%;background:var(--law);animation:lazy-bar 1.4s ease-in-out infinite"></div>
+              </div>
+              <div style="font-size:11px;opacity:.65;margin-top:18px;line-height:1.6">최초 1회만 ~10~20초<br>다음부터는 즉시 표시됩니다</div>
+            </div>
+          </div>
+          <style>@keyframes lazy-bar{0%{transform:translateX(-100%);width:40%}50%{width:70%}100%{transform:translateX(280%);width:40%}}</style>
+        `;
+        const startedAt = Date.now();
+        if (window._lazyElapsedTimerH) clearInterval(window._lazyElapsedTimerH);
+        window._lazyElapsedTimerH = setInterval(function(){
+          const el = document.getElementById('lazyElapsedH');
+          if (!el) { clearInterval(window._lazyElapsedTimerH); return; }
+          el.textContent = Math.floor((Date.now() - startedAt)/1000) + '초 경과';
+        }, 1000);
       }
     }
-    ensureTableExtras().then(function(){ renderHistory(); }).catch(function(){});
+    ensureTableExtras().then(function(){
+      if (window._lazyElapsedTimerH) { clearInterval(window._lazyElapsedTimerH); window._lazyElapsedTimerH = null; }
+      renderHistory();
+    }).catch(function(){
+      if (window._lazyElapsedTimerH) { clearInterval(window._lazyElapsedTimerH); window._lazyElapsedTimerH = null; }
+    });
     return;
   }
   // Phase 3 S3-1-b-4-b: 시행령·시행규칙 직접 진입 시 단순 diff 연혁

--- a/viewer_crim_proc.html
+++ b/viewer_crim_proc.html
@@ -377,7 +377,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_crim_proc.js?v=20260527211902"></script>
+<script src="web_data/data_core_crim_proc.js?v=20260527212745"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -392,7 +392,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527211902';
+const _LAZY_TS = '20260527212745';
 const _LAZY_SFX = '_crim_proc';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -1329,7 +1329,7 @@ function togFull(id,lawType,joKey,hang){
 }
 
 function openTable(lawType,ref){
-  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 모달 스피너 후 데이터 도착 시 재호출
+  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
   if (_lazyTable.status !== 'ready') {
     const overlay=document.getElementById('modalOverlay');
     const titleEl=document.getElementById('modalTitle');
@@ -1340,10 +1340,35 @@ function openTable(lawType,ref){
       if (_lazyTable.status === 'error') {
         bodyEl.innerHTML='<div style="text-align:center;padding:40px;color:#c0392b;font-size:14px">별표 자료를 불러오지 못했습니다.<br><br><button onclick="openTable(\''+lawType+'\',\''+ref+'\')" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div>';
       } else {
-        bodyEl.innerHTML='<div style="text-align:center;padding:60px 20px;color:var(--sub);font-size:14px"><div style="font-size:24px;margin-bottom:12px">⏳</div>별표 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 클릭 시에만 다운로드)</span></div>';
+        // PR-H7: 진행바 + 경과시간 카운터 — 사용자가 동작 확인 가능
+        bodyEl.innerHTML=`
+          <div style="text-align:center;padding:50px 20px;color:var(--law);font-size:14px">
+            <div style="font-size:36px;margin-bottom:14px">📑</div>
+            <div style="font-weight:600;margin-bottom:6px">별표·별지 자료 다운로드 중</div>
+            <div id="lazyElapsed" style="font-size:13px;color:var(--sub);margin-bottom:14px">0초 경과</div>
+            <div style="width:80%;max-width:280px;margin:0 auto;height:6px;background:#e5e3dd;border-radius:3px;overflow:hidden">
+              <div style="height:100%;background:var(--law);animation:lazy-bar 1.4s ease-in-out infinite"></div>
+            </div>
+            <div style="font-size:11px;opacity:.65;margin-top:18px;line-height:1.6">최초 1회만 ~10~20초<br>다음부터는 즉시 표시됩니다</div>
+          </div>
+          <style>@keyframes lazy-bar{0%{transform:translateX(-100%);width:40%}50%{width:70%}100%{transform:translateX(280%);width:40%}}</style>
+        `;
+        // 경과시간 카운터 (1초마다 갱신, lazy ready 시 자동 정리)
+        const startedAt = Date.now();
+        if (window._lazyElapsedTimer) clearInterval(window._lazyElapsedTimer);
+        window._lazyElapsedTimer = setInterval(function(){
+          const el = document.getElementById('lazyElapsed');
+          if (!el) { clearInterval(window._lazyElapsedTimer); return; }
+          el.textContent = Math.floor((Date.now() - startedAt)/1000) + '초 경과';
+        }, 1000);
       }
     }
-    ensureTableExtras().then(function(){ openTable(lawType, ref); }).catch(function(){});
+    ensureTableExtras().then(function(){
+      if (window._lazyElapsedTimer) { clearInterval(window._lazyElapsedTimer); window._lazyElapsedTimer = null; }
+      openTable(lawType, ref);
+    }).catch(function(){
+      if (window._lazyElapsedTimer) { clearInterval(window._lazyElapsedTimer); window._lazyElapsedTimer = null; }
+    });
     return;
   }
   // ref: "별표 16", "별지 제39호서식" 등
@@ -1561,17 +1586,42 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
-  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 historyContent 스피너 후 도착 시 재호출
+  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
   if (_lazyTable.status !== 'ready') {
     const hc = document.getElementById('historyContent');
     if (hc) {
       if (_lazyTable.status === 'error') {
         hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
       } else {
-        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:60px 20px;color:var(--sub)"><div style="font-size:24px;margin-bottom:12px">⏳</div>연혁 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 진입 시에만 다운로드)</span></div></div>';
+        hc.innerHTML = `
+          <div class="main">
+            <div style="text-align:center;padding:60px 20px;color:var(--law)">
+              <div style="font-size:40px;margin-bottom:14px">📜</div>
+              <div style="font-weight:600;font-size:15px;margin-bottom:6px">연혁 자료 다운로드 중</div>
+              <div id="lazyElapsedH" style="font-size:13px;color:var(--sub);margin-bottom:14px">0초 경과</div>
+              <div style="width:80%;max-width:280px;margin:0 auto;height:6px;background:#e5e3dd;border-radius:3px;overflow:hidden">
+                <div style="height:100%;background:var(--law);animation:lazy-bar 1.4s ease-in-out infinite"></div>
+              </div>
+              <div style="font-size:11px;opacity:.65;margin-top:18px;line-height:1.6">최초 1회만 ~10~20초<br>다음부터는 즉시 표시됩니다</div>
+            </div>
+          </div>
+          <style>@keyframes lazy-bar{0%{transform:translateX(-100%);width:40%}50%{width:70%}100%{transform:translateX(280%);width:40%}}</style>
+        `;
+        const startedAt = Date.now();
+        if (window._lazyElapsedTimerH) clearInterval(window._lazyElapsedTimerH);
+        window._lazyElapsedTimerH = setInterval(function(){
+          const el = document.getElementById('lazyElapsedH');
+          if (!el) { clearInterval(window._lazyElapsedTimerH); return; }
+          el.textContent = Math.floor((Date.now() - startedAt)/1000) + '초 경과';
+        }, 1000);
       }
     }
-    ensureTableExtras().then(function(){ renderHistory(); }).catch(function(){});
+    ensureTableExtras().then(function(){
+      if (window._lazyElapsedTimerH) { clearInterval(window._lazyElapsedTimerH); window._lazyElapsedTimerH = null; }
+      renderHistory();
+    }).catch(function(){
+      if (window._lazyElapsedTimerH) { clearInterval(window._lazyElapsedTimerH); window._lazyElapsedTimerH = null; }
+    });
     return;
   }
   // Phase 3 S3-1-b-4-b: 시행령·시행규칙 직접 진입 시 단순 diff 연혁

--- a/viewer_passenger_transport.html
+++ b/viewer_passenger_transport.html
@@ -377,7 +377,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_passenger_transport.js?v=20260527211900"></script>
+<script src="web_data/data_core_passenger_transport.js?v=20260527212744"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -392,7 +392,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527211900';
+const _LAZY_TS = '20260527212744';
 const _LAZY_SFX = '_passenger_transport';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -1329,7 +1329,7 @@ function togFull(id,lawType,joKey,hang){
 }
 
 function openTable(lawType,ref){
-  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 모달 스피너 후 데이터 도착 시 재호출
+  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
   if (_lazyTable.status !== 'ready') {
     const overlay=document.getElementById('modalOverlay');
     const titleEl=document.getElementById('modalTitle');
@@ -1340,10 +1340,35 @@ function openTable(lawType,ref){
       if (_lazyTable.status === 'error') {
         bodyEl.innerHTML='<div style="text-align:center;padding:40px;color:#c0392b;font-size:14px">별표 자료를 불러오지 못했습니다.<br><br><button onclick="openTable(\''+lawType+'\',\''+ref+'\')" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div>';
       } else {
-        bodyEl.innerHTML='<div style="text-align:center;padding:60px 20px;color:var(--sub);font-size:14px"><div style="font-size:24px;margin-bottom:12px">⏳</div>별표 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 클릭 시에만 다운로드)</span></div>';
+        // PR-H7: 진행바 + 경과시간 카운터 — 사용자가 동작 확인 가능
+        bodyEl.innerHTML=`
+          <div style="text-align:center;padding:50px 20px;color:var(--law);font-size:14px">
+            <div style="font-size:36px;margin-bottom:14px">📑</div>
+            <div style="font-weight:600;margin-bottom:6px">별표·별지 자료 다운로드 중</div>
+            <div id="lazyElapsed" style="font-size:13px;color:var(--sub);margin-bottom:14px">0초 경과</div>
+            <div style="width:80%;max-width:280px;margin:0 auto;height:6px;background:#e5e3dd;border-radius:3px;overflow:hidden">
+              <div style="height:100%;background:var(--law);animation:lazy-bar 1.4s ease-in-out infinite"></div>
+            </div>
+            <div style="font-size:11px;opacity:.65;margin-top:18px;line-height:1.6">최초 1회만 ~10~20초<br>다음부터는 즉시 표시됩니다</div>
+          </div>
+          <style>@keyframes lazy-bar{0%{transform:translateX(-100%);width:40%}50%{width:70%}100%{transform:translateX(280%);width:40%}}</style>
+        `;
+        // 경과시간 카운터 (1초마다 갱신, lazy ready 시 자동 정리)
+        const startedAt = Date.now();
+        if (window._lazyElapsedTimer) clearInterval(window._lazyElapsedTimer);
+        window._lazyElapsedTimer = setInterval(function(){
+          const el = document.getElementById('lazyElapsed');
+          if (!el) { clearInterval(window._lazyElapsedTimer); return; }
+          el.textContent = Math.floor((Date.now() - startedAt)/1000) + '초 경과';
+        }, 1000);
       }
     }
-    ensureTableExtras().then(function(){ openTable(lawType, ref); }).catch(function(){});
+    ensureTableExtras().then(function(){
+      if (window._lazyElapsedTimer) { clearInterval(window._lazyElapsedTimer); window._lazyElapsedTimer = null; }
+      openTable(lawType, ref);
+    }).catch(function(){
+      if (window._lazyElapsedTimer) { clearInterval(window._lazyElapsedTimer); window._lazyElapsedTimer = null; }
+    });
     return;
   }
   // ref: "별표 16", "별지 제39호서식" 등
@@ -1561,17 +1586,42 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
-  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 historyContent 스피너 후 도착 시 재호출
+  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
   if (_lazyTable.status !== 'ready') {
     const hc = document.getElementById('historyContent');
     if (hc) {
       if (_lazyTable.status === 'error') {
         hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
       } else {
-        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:60px 20px;color:var(--sub)"><div style="font-size:24px;margin-bottom:12px">⏳</div>연혁 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 진입 시에만 다운로드)</span></div></div>';
+        hc.innerHTML = `
+          <div class="main">
+            <div style="text-align:center;padding:60px 20px;color:var(--law)">
+              <div style="font-size:40px;margin-bottom:14px">📜</div>
+              <div style="font-weight:600;font-size:15px;margin-bottom:6px">연혁 자료 다운로드 중</div>
+              <div id="lazyElapsedH" style="font-size:13px;color:var(--sub);margin-bottom:14px">0초 경과</div>
+              <div style="width:80%;max-width:280px;margin:0 auto;height:6px;background:#e5e3dd;border-radius:3px;overflow:hidden">
+                <div style="height:100%;background:var(--law);animation:lazy-bar 1.4s ease-in-out infinite"></div>
+              </div>
+              <div style="font-size:11px;opacity:.65;margin-top:18px;line-height:1.6">최초 1회만 ~10~20초<br>다음부터는 즉시 표시됩니다</div>
+            </div>
+          </div>
+          <style>@keyframes lazy-bar{0%{transform:translateX(-100%);width:40%}50%{width:70%}100%{transform:translateX(280%);width:40%}}</style>
+        `;
+        const startedAt = Date.now();
+        if (window._lazyElapsedTimerH) clearInterval(window._lazyElapsedTimerH);
+        window._lazyElapsedTimerH = setInterval(function(){
+          const el = document.getElementById('lazyElapsedH');
+          if (!el) { clearInterval(window._lazyElapsedTimerH); return; }
+          el.textContent = Math.floor((Date.now() - startedAt)/1000) + '초 경과';
+        }, 1000);
       }
     }
-    ensureTableExtras().then(function(){ renderHistory(); }).catch(function(){});
+    ensureTableExtras().then(function(){
+      if (window._lazyElapsedTimerH) { clearInterval(window._lazyElapsedTimerH); window._lazyElapsedTimerH = null; }
+      renderHistory();
+    }).catch(function(){
+      if (window._lazyElapsedTimerH) { clearInterval(window._lazyElapsedTimerH); window._lazyElapsedTimerH = null; }
+    });
     return;
   }
   // Phase 3 S3-1-b-4-b: 시행령·시행규칙 직접 진입 시 단순 diff 연혁

--- a/viewer_tkga.html
+++ b/viewer_tkga.html
@@ -377,7 +377,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_tkga.js?v=20260527211856"></script>
+<script src="web_data/data_core_tkga.js?v=20260527212739"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -392,7 +392,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527211856';
+const _LAZY_TS = '20260527212739';
 const _LAZY_SFX = '_tkga';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -1329,7 +1329,7 @@ function togFull(id,lawType,joKey,hang){
 }
 
 function openTable(lawType,ref){
-  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 모달 스피너 후 데이터 도착 시 재호출
+  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
   if (_lazyTable.status !== 'ready') {
     const overlay=document.getElementById('modalOverlay');
     const titleEl=document.getElementById('modalTitle');
@@ -1340,10 +1340,35 @@ function openTable(lawType,ref){
       if (_lazyTable.status === 'error') {
         bodyEl.innerHTML='<div style="text-align:center;padding:40px;color:#c0392b;font-size:14px">별표 자료를 불러오지 못했습니다.<br><br><button onclick="openTable(\''+lawType+'\',\''+ref+'\')" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div>';
       } else {
-        bodyEl.innerHTML='<div style="text-align:center;padding:60px 20px;color:var(--sub);font-size:14px"><div style="font-size:24px;margin-bottom:12px">⏳</div>별표 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 클릭 시에만 다운로드)</span></div>';
+        // PR-H7: 진행바 + 경과시간 카운터 — 사용자가 동작 확인 가능
+        bodyEl.innerHTML=`
+          <div style="text-align:center;padding:50px 20px;color:var(--law);font-size:14px">
+            <div style="font-size:36px;margin-bottom:14px">📑</div>
+            <div style="font-weight:600;margin-bottom:6px">별표·별지 자료 다운로드 중</div>
+            <div id="lazyElapsed" style="font-size:13px;color:var(--sub);margin-bottom:14px">0초 경과</div>
+            <div style="width:80%;max-width:280px;margin:0 auto;height:6px;background:#e5e3dd;border-radius:3px;overflow:hidden">
+              <div style="height:100%;background:var(--law);animation:lazy-bar 1.4s ease-in-out infinite"></div>
+            </div>
+            <div style="font-size:11px;opacity:.65;margin-top:18px;line-height:1.6">최초 1회만 ~10~20초<br>다음부터는 즉시 표시됩니다</div>
+          </div>
+          <style>@keyframes lazy-bar{0%{transform:translateX(-100%);width:40%}50%{width:70%}100%{transform:translateX(280%);width:40%}}</style>
+        `;
+        // 경과시간 카운터 (1초마다 갱신, lazy ready 시 자동 정리)
+        const startedAt = Date.now();
+        if (window._lazyElapsedTimer) clearInterval(window._lazyElapsedTimer);
+        window._lazyElapsedTimer = setInterval(function(){
+          const el = document.getElementById('lazyElapsed');
+          if (!el) { clearInterval(window._lazyElapsedTimer); return; }
+          el.textContent = Math.floor((Date.now() - startedAt)/1000) + '초 경과';
+        }, 1000);
       }
     }
-    ensureTableExtras().then(function(){ openTable(lawType, ref); }).catch(function(){});
+    ensureTableExtras().then(function(){
+      if (window._lazyElapsedTimer) { clearInterval(window._lazyElapsedTimer); window._lazyElapsedTimer = null; }
+      openTable(lawType, ref);
+    }).catch(function(){
+      if (window._lazyElapsedTimer) { clearInterval(window._lazyElapsedTimer); window._lazyElapsedTimer = null; }
+    });
     return;
   }
   // ref: "별표 16", "별지 제39호서식" 등
@@ -1561,17 +1586,42 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
-  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 historyContent 스피너 후 도착 시 재호출
+  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
   if (_lazyTable.status !== 'ready') {
     const hc = document.getElementById('historyContent');
     if (hc) {
       if (_lazyTable.status === 'error') {
         hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
       } else {
-        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:60px 20px;color:var(--sub)"><div style="font-size:24px;margin-bottom:12px">⏳</div>연혁 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 진입 시에만 다운로드)</span></div></div>';
+        hc.innerHTML = `
+          <div class="main">
+            <div style="text-align:center;padding:60px 20px;color:var(--law)">
+              <div style="font-size:40px;margin-bottom:14px">📜</div>
+              <div style="font-weight:600;font-size:15px;margin-bottom:6px">연혁 자료 다운로드 중</div>
+              <div id="lazyElapsedH" style="font-size:13px;color:var(--sub);margin-bottom:14px">0초 경과</div>
+              <div style="width:80%;max-width:280px;margin:0 auto;height:6px;background:#e5e3dd;border-radius:3px;overflow:hidden">
+                <div style="height:100%;background:var(--law);animation:lazy-bar 1.4s ease-in-out infinite"></div>
+              </div>
+              <div style="font-size:11px;opacity:.65;margin-top:18px;line-height:1.6">최초 1회만 ~10~20초<br>다음부터는 즉시 표시됩니다</div>
+            </div>
+          </div>
+          <style>@keyframes lazy-bar{0%{transform:translateX(-100%);width:40%}50%{width:70%}100%{transform:translateX(280%);width:40%}}</style>
+        `;
+        const startedAt = Date.now();
+        if (window._lazyElapsedTimerH) clearInterval(window._lazyElapsedTimerH);
+        window._lazyElapsedTimerH = setInterval(function(){
+          const el = document.getElementById('lazyElapsedH');
+          if (!el) { clearInterval(window._lazyElapsedTimerH); return; }
+          el.textContent = Math.floor((Date.now() - startedAt)/1000) + '초 경과';
+        }, 1000);
       }
     }
-    ensureTableExtras().then(function(){ renderHistory(); }).catch(function(){});
+    ensureTableExtras().then(function(){
+      if (window._lazyElapsedTimerH) { clearInterval(window._lazyElapsedTimerH); window._lazyElapsedTimerH = null; }
+      renderHistory();
+    }).catch(function(){
+      if (window._lazyElapsedTimerH) { clearInterval(window._lazyElapsedTimerH); window._lazyElapsedTimerH = null; }
+    });
     return;
   }
   // Phase 3 S3-1-b-4-b: 시행령·시행규칙 직접 진입 시 단순 diff 연혁

--- a/viewer_tlspc.html
+++ b/viewer_tlspc.html
@@ -377,7 +377,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_tlspc.js?v=20260527211855"></script>
+<script src="web_data/data_core_tlspc.js?v=20260527212738"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -392,7 +392,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527211855';
+const _LAZY_TS = '20260527212738';
 const _LAZY_SFX = '_tlspc';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -1329,7 +1329,7 @@ function togFull(id,lawType,joKey,hang){
 }
 
 function openTable(lawType,ref){
-  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 모달 스피너 후 데이터 도착 시 재호출
+  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
   if (_lazyTable.status !== 'ready') {
     const overlay=document.getElementById('modalOverlay');
     const titleEl=document.getElementById('modalTitle');
@@ -1340,10 +1340,35 @@ function openTable(lawType,ref){
       if (_lazyTable.status === 'error') {
         bodyEl.innerHTML='<div style="text-align:center;padding:40px;color:#c0392b;font-size:14px">별표 자료를 불러오지 못했습니다.<br><br><button onclick="openTable(\''+lawType+'\',\''+ref+'\')" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div>';
       } else {
-        bodyEl.innerHTML='<div style="text-align:center;padding:60px 20px;color:var(--sub);font-size:14px"><div style="font-size:24px;margin-bottom:12px">⏳</div>별표 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 클릭 시에만 다운로드)</span></div>';
+        // PR-H7: 진행바 + 경과시간 카운터 — 사용자가 동작 확인 가능
+        bodyEl.innerHTML=`
+          <div style="text-align:center;padding:50px 20px;color:var(--law);font-size:14px">
+            <div style="font-size:36px;margin-bottom:14px">📑</div>
+            <div style="font-weight:600;margin-bottom:6px">별표·별지 자료 다운로드 중</div>
+            <div id="lazyElapsed" style="font-size:13px;color:var(--sub);margin-bottom:14px">0초 경과</div>
+            <div style="width:80%;max-width:280px;margin:0 auto;height:6px;background:#e5e3dd;border-radius:3px;overflow:hidden">
+              <div style="height:100%;background:var(--law);animation:lazy-bar 1.4s ease-in-out infinite"></div>
+            </div>
+            <div style="font-size:11px;opacity:.65;margin-top:18px;line-height:1.6">최초 1회만 ~10~20초<br>다음부터는 즉시 표시됩니다</div>
+          </div>
+          <style>@keyframes lazy-bar{0%{transform:translateX(-100%);width:40%}50%{width:70%}100%{transform:translateX(280%);width:40%}}</style>
+        `;
+        // 경과시간 카운터 (1초마다 갱신, lazy ready 시 자동 정리)
+        const startedAt = Date.now();
+        if (window._lazyElapsedTimer) clearInterval(window._lazyElapsedTimer);
+        window._lazyElapsedTimer = setInterval(function(){
+          const el = document.getElementById('lazyElapsed');
+          if (!el) { clearInterval(window._lazyElapsedTimer); return; }
+          el.textContent = Math.floor((Date.now() - startedAt)/1000) + '초 경과';
+        }, 1000);
       }
     }
-    ensureTableExtras().then(function(){ openTable(lawType, ref); }).catch(function(){});
+    ensureTableExtras().then(function(){
+      if (window._lazyElapsedTimer) { clearInterval(window._lazyElapsedTimer); window._lazyElapsedTimer = null; }
+      openTable(lawType, ref);
+    }).catch(function(){
+      if (window._lazyElapsedTimer) { clearInterval(window._lazyElapsedTimer); window._lazyElapsedTimer = null; }
+    });
     return;
   }
   // ref: "별표 16", "별지 제39호서식" 등
@@ -1561,17 +1586,42 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
-  // PR-H4-γ-2: 별표 자료 lazy load 가드 — 준비 안 됐으면 historyContent 스피너 후 도착 시 재호출
+  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
   if (_lazyTable.status !== 'ready') {
     const hc = document.getElementById('historyContent');
     if (hc) {
       if (_lazyTable.status === 'error') {
         hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
       } else {
-        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:60px 20px;color:var(--sub)"><div style="font-size:24px;margin-bottom:12px">⏳</div>연혁 자료 로딩 중...<br><span style="font-size:11px;opacity:.7">(첫 진입 시에만 다운로드)</span></div></div>';
+        hc.innerHTML = `
+          <div class="main">
+            <div style="text-align:center;padding:60px 20px;color:var(--law)">
+              <div style="font-size:40px;margin-bottom:14px">📜</div>
+              <div style="font-weight:600;font-size:15px;margin-bottom:6px">연혁 자료 다운로드 중</div>
+              <div id="lazyElapsedH" style="font-size:13px;color:var(--sub);margin-bottom:14px">0초 경과</div>
+              <div style="width:80%;max-width:280px;margin:0 auto;height:6px;background:#e5e3dd;border-radius:3px;overflow:hidden">
+                <div style="height:100%;background:var(--law);animation:lazy-bar 1.4s ease-in-out infinite"></div>
+              </div>
+              <div style="font-size:11px;opacity:.65;margin-top:18px;line-height:1.6">최초 1회만 ~10~20초<br>다음부터는 즉시 표시됩니다</div>
+            </div>
+          </div>
+          <style>@keyframes lazy-bar{0%{transform:translateX(-100%);width:40%}50%{width:70%}100%{transform:translateX(280%);width:40%}}</style>
+        `;
+        const startedAt = Date.now();
+        if (window._lazyElapsedTimerH) clearInterval(window._lazyElapsedTimerH);
+        window._lazyElapsedTimerH = setInterval(function(){
+          const el = document.getElementById('lazyElapsedH');
+          if (!el) { clearInterval(window._lazyElapsedTimerH); return; }
+          el.textContent = Math.floor((Date.now() - startedAt)/1000) + '초 경과';
+        }, 1000);
       }
     }
-    ensureTableExtras().then(function(){ renderHistory(); }).catch(function(){});
+    ensureTableExtras().then(function(){
+      if (window._lazyElapsedTimerH) { clearInterval(window._lazyElapsedTimerH); window._lazyElapsedTimerH = null; }
+      renderHistory();
+    }).catch(function(){
+      if (window._lazyElapsedTimerH) { clearInterval(window._lazyElapsedTimerH); window._lazyElapsedTimerH = null; }
+    });
     return;
   }
   // Phase 3 S3-1-b-4-b: 시행령·시행규칙 직접 진입 시 단순 diff 연혁


### PR DESCRIPTION
## 사용자 보고
별표/별지 처음 로딩 시 진행 상태 알기 어려움 — 정적 ⏳ 텍스트만 있어 멈췄는지 판단 어려움.

## 수정
**openTable·renderHistory 가드에 진행 가시화**:
- CSS animation 진행바 (indeterminate, 1.4s 루프)
- 경과시간 카운터 (`N초 경과`, 1초마다 갱신)
- 아이콘 크게 + 안내문 명확화 (`최초 1회만 ~10~20초`)
- lazy ready 시 timer 자동 정리

## UX 개선
- 사용자가 동작 중임을 시각적으로 즉시 인지
- 경과시간 카운트로 멈춤 여부 확인 가능
- 예상 시간 안내로 인내심 ↑

## Test plan
- [ ] 별표/별지 처음 클릭 시 진행바 + N초 경과 정상 표시
- [ ] 로딩 완료 후 PDF 정상 미리보기 (timer 정리 확인)
- [ ] 연혁 탭 첫 클릭 시 동일 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)