### PR TITLE
fix: 최근 개정 알림 → 조문 이동 안 되던 문제 해결

### DIFF
--- a/generate_viewer.py
+++ b/generate_viewer.py
@@ -3085,16 +3085,36 @@ document.addEventListener('keydown',e=>{
 });
 
 // alarm.html(iframe)로부터 "연혁 보기" 메시지 수신 → 모달 닫고 메인 페이지에서 조문 이동
-// alarm.html이 이미 "매핑된 법률 조문 키"로 변환해서 보내므로 그대로 사용 (fallback 불필요)
+// PR-H8-fix: 이전엔 location.href로 reload 시도했으나 ?jo= 파라미터만 바뀌면
+//            브라우저가 reload 안 하고 URL만 바뀌어 화면 그대로 → 사용자 보고 안 될 때 多.
+//            SPA 방식으로 switchLawType + goArticle + switchTab 직접 호출하여 즉시 화면 전환.
 window.addEventListener('message',e=>{
   if(!e.data || e.data.type!=='goToHistory') return;
   closeAlarmModal();
-  const url=new URL(window.location.href);
-  url.searchParams.set('jo',e.data.jo);
-  url.searchParams.set('tab','history');
-  // Phase 3 S3-1-b-4-b 사후검증: 알람은 항상 법률 조문 기준이므로 law 파라미터 잔존 시 제거
-  url.searchParams.delete('law');
-  window.location.href=url.toString();
+  const targetJo = e.data.jo;
+  // 1) 법률 토글로 전환 (알람은 항상 법률 조문 기준)
+  if (typeof switchLawType === 'function' && currentLawType !== '법률') {
+    switchLawType('법률');
+  }
+  // 2) 조문 이동 (sel.value 설정 + render)
+  if (typeof goArticle === 'function') {
+    goArticle(targetJo);
+  } else {
+    const sel = document.getElementById('sel');
+    if (sel) sel.value = targetJo;
+  }
+  // 3) 연혁 탭으로 전환
+  if (typeof switchTab === 'function') {
+    switchTab('history');
+  }
+  // 4) URL 동기화 (reload 없이) — 새로고침해도 같은 조문 유지
+  try {
+    const url = new URL(window.location.href);
+    url.searchParams.set('jo', targetJo);
+    url.searchParams.set('tab', 'history');
+    url.searchParams.delete('law');
+    history.replaceState(null, '', url.toString());
+  } catch(_) {}
 });
 
 // PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)

--- a/viewer.html
+++ b/viewer.html
@@ -386,7 +386,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core.js?v=20260527215739"></script>
+<script src="web_data/data_core.js?v=20260527220249"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -401,7 +401,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527215739';
+const _LAZY_TS = '20260527220249';
 const _LAZY_SFX = '';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -2588,16 +2588,36 @@ document.addEventListener('keydown',e=>{
 });
 
 // alarm.html(iframe)로부터 "연혁 보기" 메시지 수신 → 모달 닫고 메인 페이지에서 조문 이동
-// alarm.html이 이미 "매핑된 법률 조문 키"로 변환해서 보내므로 그대로 사용 (fallback 불필요)
+// PR-H8-fix: 이전엔 location.href로 reload 시도했으나 ?jo= 파라미터만 바뀌면
+//            브라우저가 reload 안 하고 URL만 바뀌어 화면 그대로 → 사용자 보고 안 될 때 多.
+//            SPA 방식으로 switchLawType + goArticle + switchTab 직접 호출하여 즉시 화면 전환.
 window.addEventListener('message',e=>{
   if(!e.data || e.data.type!=='goToHistory') return;
   closeAlarmModal();
-  const url=new URL(window.location.href);
-  url.searchParams.set('jo',e.data.jo);
-  url.searchParams.set('tab','history');
-  // Phase 3 S3-1-b-4-b 사후검증: 알람은 항상 법률 조문 기준이므로 law 파라미터 잔존 시 제거
-  url.searchParams.delete('law');
-  window.location.href=url.toString();
+  const targetJo = e.data.jo;
+  // 1) 법률 토글로 전환 (알람은 항상 법률 조문 기준)
+  if (typeof switchLawType === 'function' && currentLawType !== '법률') {
+    switchLawType('법률');
+  }
+  // 2) 조문 이동 (sel.value 설정 + render)
+  if (typeof goArticle === 'function') {
+    goArticle(targetJo);
+  } else {
+    const sel = document.getElementById('sel');
+    if (sel) sel.value = targetJo;
+  }
+  // 3) 연혁 탭으로 전환
+  if (typeof switchTab === 'function') {
+    switchTab('history');
+  }
+  // 4) URL 동기화 (reload 없이) — 새로고침해도 같은 조문 유지
+  try {
+    const url = new URL(window.location.href);
+    url.searchParams.set('jo', targetJo);
+    url.searchParams.set('tab', 'history');
+    url.searchParams.delete('law');
+    history.replaceState(null, '', url.toString());
+  } catch(_) {}
 });
 
 // PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)

--- a/viewer_car_mgmt.html
+++ b/viewer_car_mgmt.html
@@ -385,7 +385,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_car_mgmt.js?v=20260527215743"></script>
+<script src="web_data/data_core_car_mgmt.js?v=20260527220253"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -400,7 +400,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527215743';
+const _LAZY_TS = '20260527220253';
 const _LAZY_SFX = '_car_mgmt';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -2587,16 +2587,36 @@ document.addEventListener('keydown',e=>{
 });
 
 // alarm.html(iframe)로부터 "연혁 보기" 메시지 수신 → 모달 닫고 메인 페이지에서 조문 이동
-// alarm.html이 이미 "매핑된 법률 조문 키"로 변환해서 보내므로 그대로 사용 (fallback 불필요)
+// PR-H8-fix: 이전엔 location.href로 reload 시도했으나 ?jo= 파라미터만 바뀌면
+//            브라우저가 reload 안 하고 URL만 바뀌어 화면 그대로 → 사용자 보고 안 될 때 多.
+//            SPA 방식으로 switchLawType + goArticle + switchTab 직접 호출하여 즉시 화면 전환.
 window.addEventListener('message',e=>{
   if(!e.data || e.data.type!=='goToHistory') return;
   closeAlarmModal();
-  const url=new URL(window.location.href);
-  url.searchParams.set('jo',e.data.jo);
-  url.searchParams.set('tab','history');
-  // Phase 3 S3-1-b-4-b 사후검증: 알람은 항상 법률 조문 기준이므로 law 파라미터 잔존 시 제거
-  url.searchParams.delete('law');
-  window.location.href=url.toString();
+  const targetJo = e.data.jo;
+  // 1) 법률 토글로 전환 (알람은 항상 법률 조문 기준)
+  if (typeof switchLawType === 'function' && currentLawType !== '법률') {
+    switchLawType('법률');
+  }
+  // 2) 조문 이동 (sel.value 설정 + render)
+  if (typeof goArticle === 'function') {
+    goArticle(targetJo);
+  } else {
+    const sel = document.getElementById('sel');
+    if (sel) sel.value = targetJo;
+  }
+  // 3) 연혁 탭으로 전환
+  if (typeof switchTab === 'function') {
+    switchTab('history');
+  }
+  // 4) URL 동기화 (reload 없이) — 새로고침해도 같은 조문 유지
+  try {
+    const url = new URL(window.location.href);
+    url.searchParams.set('jo', targetJo);
+    url.searchParams.set('tab', 'history');
+    url.searchParams.delete('law');
+    history.replaceState(null, '', url.toString());
+  } catch(_) {}
 });
 
 // PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)

--- a/viewer_cargo_transport.html
+++ b/viewer_cargo_transport.html
@@ -385,7 +385,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_cargo_transport.js?v=20260527215745"></script>
+<script src="web_data/data_core_cargo_transport.js?v=20260527220256"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -400,7 +400,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527215745';
+const _LAZY_TS = '20260527220256';
 const _LAZY_SFX = '_cargo_transport';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -2587,16 +2587,36 @@ document.addEventListener('keydown',e=>{
 });
 
 // alarm.html(iframe)로부터 "연혁 보기" 메시지 수신 → 모달 닫고 메인 페이지에서 조문 이동
-// alarm.html이 이미 "매핑된 법률 조문 키"로 변환해서 보내므로 그대로 사용 (fallback 불필요)
+// PR-H8-fix: 이전엔 location.href로 reload 시도했으나 ?jo= 파라미터만 바뀌면
+//            브라우저가 reload 안 하고 URL만 바뀌어 화면 그대로 → 사용자 보고 안 될 때 多.
+//            SPA 방식으로 switchLawType + goArticle + switchTab 직접 호출하여 즉시 화면 전환.
 window.addEventListener('message',e=>{
   if(!e.data || e.data.type!=='goToHistory') return;
   closeAlarmModal();
-  const url=new URL(window.location.href);
-  url.searchParams.set('jo',e.data.jo);
-  url.searchParams.set('tab','history');
-  // Phase 3 S3-1-b-4-b 사후검증: 알람은 항상 법률 조문 기준이므로 law 파라미터 잔존 시 제거
-  url.searchParams.delete('law');
-  window.location.href=url.toString();
+  const targetJo = e.data.jo;
+  // 1) 법률 토글로 전환 (알람은 항상 법률 조문 기준)
+  if (typeof switchLawType === 'function' && currentLawType !== '법률') {
+    switchLawType('법률');
+  }
+  // 2) 조문 이동 (sel.value 설정 + render)
+  if (typeof goArticle === 'function') {
+    goArticle(targetJo);
+  } else {
+    const sel = document.getElementById('sel');
+    if (sel) sel.value = targetJo;
+  }
+  // 3) 연혁 탭으로 전환
+  if (typeof switchTab === 'function') {
+    switchTab('history');
+  }
+  // 4) URL 동기화 (reload 없이) — 새로고침해도 같은 조문 유지
+  try {
+    const url = new URL(window.location.href);
+    url.searchParams.set('jo', targetJo);
+    url.searchParams.set('tab', 'history');
+    url.searchParams.delete('law');
+    history.replaceState(null, '', url.toString());
+  } catch(_) {}
 });
 
 // PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)

--- a/viewer_crim_proc.html
+++ b/viewer_crim_proc.html
@@ -385,7 +385,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_crim_proc.js?v=20260527215746"></script>
+<script src="web_data/data_core_crim_proc.js?v=20260527220257"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -400,7 +400,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527215746';
+const _LAZY_TS = '20260527220257';
 const _LAZY_SFX = '_crim_proc';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -2587,16 +2587,36 @@ document.addEventListener('keydown',e=>{
 });
 
 // alarm.html(iframe)로부터 "연혁 보기" 메시지 수신 → 모달 닫고 메인 페이지에서 조문 이동
-// alarm.html이 이미 "매핑된 법률 조문 키"로 변환해서 보내므로 그대로 사용 (fallback 불필요)
+// PR-H8-fix: 이전엔 location.href로 reload 시도했으나 ?jo= 파라미터만 바뀌면
+//            브라우저가 reload 안 하고 URL만 바뀌어 화면 그대로 → 사용자 보고 안 될 때 多.
+//            SPA 방식으로 switchLawType + goArticle + switchTab 직접 호출하여 즉시 화면 전환.
 window.addEventListener('message',e=>{
   if(!e.data || e.data.type!=='goToHistory') return;
   closeAlarmModal();
-  const url=new URL(window.location.href);
-  url.searchParams.set('jo',e.data.jo);
-  url.searchParams.set('tab','history');
-  // Phase 3 S3-1-b-4-b 사후검증: 알람은 항상 법률 조문 기준이므로 law 파라미터 잔존 시 제거
-  url.searchParams.delete('law');
-  window.location.href=url.toString();
+  const targetJo = e.data.jo;
+  // 1) 법률 토글로 전환 (알람은 항상 법률 조문 기준)
+  if (typeof switchLawType === 'function' && currentLawType !== '법률') {
+    switchLawType('법률');
+  }
+  // 2) 조문 이동 (sel.value 설정 + render)
+  if (typeof goArticle === 'function') {
+    goArticle(targetJo);
+  } else {
+    const sel = document.getElementById('sel');
+    if (sel) sel.value = targetJo;
+  }
+  // 3) 연혁 탭으로 전환
+  if (typeof switchTab === 'function') {
+    switchTab('history');
+  }
+  // 4) URL 동기화 (reload 없이) — 새로고침해도 같은 조문 유지
+  try {
+    const url = new URL(window.location.href);
+    url.searchParams.set('jo', targetJo);
+    url.searchParams.set('tab', 'history');
+    url.searchParams.delete('law');
+    history.replaceState(null, '', url.toString());
+  } catch(_) {}
 });
 
 // PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)

--- a/viewer_passenger_transport.html
+++ b/viewer_passenger_transport.html
@@ -385,7 +385,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_passenger_transport.js?v=20260527215744"></script>
+<script src="web_data/data_core_passenger_transport.js?v=20260527220255"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -400,7 +400,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527215744';
+const _LAZY_TS = '20260527220255';
 const _LAZY_SFX = '_passenger_transport';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -2587,16 +2587,36 @@ document.addEventListener('keydown',e=>{
 });
 
 // alarm.html(iframe)로부터 "연혁 보기" 메시지 수신 → 모달 닫고 메인 페이지에서 조문 이동
-// alarm.html이 이미 "매핑된 법률 조문 키"로 변환해서 보내므로 그대로 사용 (fallback 불필요)
+// PR-H8-fix: 이전엔 location.href로 reload 시도했으나 ?jo= 파라미터만 바뀌면
+//            브라우저가 reload 안 하고 URL만 바뀌어 화면 그대로 → 사용자 보고 안 될 때 多.
+//            SPA 방식으로 switchLawType + goArticle + switchTab 직접 호출하여 즉시 화면 전환.
 window.addEventListener('message',e=>{
   if(!e.data || e.data.type!=='goToHistory') return;
   closeAlarmModal();
-  const url=new URL(window.location.href);
-  url.searchParams.set('jo',e.data.jo);
-  url.searchParams.set('tab','history');
-  // Phase 3 S3-1-b-4-b 사후검증: 알람은 항상 법률 조문 기준이므로 law 파라미터 잔존 시 제거
-  url.searchParams.delete('law');
-  window.location.href=url.toString();
+  const targetJo = e.data.jo;
+  // 1) 법률 토글로 전환 (알람은 항상 법률 조문 기준)
+  if (typeof switchLawType === 'function' && currentLawType !== '법률') {
+    switchLawType('법률');
+  }
+  // 2) 조문 이동 (sel.value 설정 + render)
+  if (typeof goArticle === 'function') {
+    goArticle(targetJo);
+  } else {
+    const sel = document.getElementById('sel');
+    if (sel) sel.value = targetJo;
+  }
+  // 3) 연혁 탭으로 전환
+  if (typeof switchTab === 'function') {
+    switchTab('history');
+  }
+  // 4) URL 동기화 (reload 없이) — 새로고침해도 같은 조문 유지
+  try {
+    const url = new URL(window.location.href);
+    url.searchParams.set('jo', targetJo);
+    url.searchParams.set('tab', 'history');
+    url.searchParams.delete('law');
+    history.replaceState(null, '', url.toString());
+  } catch(_) {}
 });
 
 // PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)

--- a/viewer_tkga.html
+++ b/viewer_tkga.html
@@ -385,7 +385,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_tkga.js?v=20260527215740"></script>
+<script src="web_data/data_core_tkga.js?v=20260527220250"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -400,7 +400,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527215740';
+const _LAZY_TS = '20260527220250';
 const _LAZY_SFX = '_tkga';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -2587,16 +2587,36 @@ document.addEventListener('keydown',e=>{
 });
 
 // alarm.html(iframe)로부터 "연혁 보기" 메시지 수신 → 모달 닫고 메인 페이지에서 조문 이동
-// alarm.html이 이미 "매핑된 법률 조문 키"로 변환해서 보내므로 그대로 사용 (fallback 불필요)
+// PR-H8-fix: 이전엔 location.href로 reload 시도했으나 ?jo= 파라미터만 바뀌면
+//            브라우저가 reload 안 하고 URL만 바뀌어 화면 그대로 → 사용자 보고 안 될 때 多.
+//            SPA 방식으로 switchLawType + goArticle + switchTab 직접 호출하여 즉시 화면 전환.
 window.addEventListener('message',e=>{
   if(!e.data || e.data.type!=='goToHistory') return;
   closeAlarmModal();
-  const url=new URL(window.location.href);
-  url.searchParams.set('jo',e.data.jo);
-  url.searchParams.set('tab','history');
-  // Phase 3 S3-1-b-4-b 사후검증: 알람은 항상 법률 조문 기준이므로 law 파라미터 잔존 시 제거
-  url.searchParams.delete('law');
-  window.location.href=url.toString();
+  const targetJo = e.data.jo;
+  // 1) 법률 토글로 전환 (알람은 항상 법률 조문 기준)
+  if (typeof switchLawType === 'function' && currentLawType !== '법률') {
+    switchLawType('법률');
+  }
+  // 2) 조문 이동 (sel.value 설정 + render)
+  if (typeof goArticle === 'function') {
+    goArticle(targetJo);
+  } else {
+    const sel = document.getElementById('sel');
+    if (sel) sel.value = targetJo;
+  }
+  // 3) 연혁 탭으로 전환
+  if (typeof switchTab === 'function') {
+    switchTab('history');
+  }
+  // 4) URL 동기화 (reload 없이) — 새로고침해도 같은 조문 유지
+  try {
+    const url = new URL(window.location.href);
+    url.searchParams.set('jo', targetJo);
+    url.searchParams.set('tab', 'history');
+    url.searchParams.delete('law');
+    history.replaceState(null, '', url.toString());
+  } catch(_) {}
 });
 
 // PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)

--- a/viewer_tlspc.html
+++ b/viewer_tlspc.html
@@ -385,7 +385,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- 데이터 분리 로드 (GitHub Pages 단일파일 100MB 한도 대응) -->
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
-<script src="web_data/data_core_tlspc.js?v=20260527215739"></script>
+<script src="web_data/data_core_tlspc.js?v=20260527220250"></script>
 <!-- PR-H6: data_core.js 로드 완료 직후 loading overlay 숨김 (사용자에게 즉시 컨텐츠 노출) -->
 <script>(function(){var o=document.getElementById('loadingOverlay');if(o)o.style.display='none';})();</script>
 <script>
@@ -400,7 +400,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527215739';
+const _LAZY_TS = '20260527220250';
 const _LAZY_SFX = '_tlspc';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -2587,16 +2587,36 @@ document.addEventListener('keydown',e=>{
 });
 
 // alarm.html(iframe)로부터 "연혁 보기" 메시지 수신 → 모달 닫고 메인 페이지에서 조문 이동
-// alarm.html이 이미 "매핑된 법률 조문 키"로 변환해서 보내므로 그대로 사용 (fallback 불필요)
+// PR-H8-fix: 이전엔 location.href로 reload 시도했으나 ?jo= 파라미터만 바뀌면
+//            브라우저가 reload 안 하고 URL만 바뀌어 화면 그대로 → 사용자 보고 안 될 때 多.
+//            SPA 방식으로 switchLawType + goArticle + switchTab 직접 호출하여 즉시 화면 전환.
 window.addEventListener('message',e=>{
   if(!e.data || e.data.type!=='goToHistory') return;
   closeAlarmModal();
-  const url=new URL(window.location.href);
-  url.searchParams.set('jo',e.data.jo);
-  url.searchParams.set('tab','history');
-  // Phase 3 S3-1-b-4-b 사후검증: 알람은 항상 법률 조문 기준이므로 law 파라미터 잔존 시 제거
-  url.searchParams.delete('law');
-  window.location.href=url.toString();
+  const targetJo = e.data.jo;
+  // 1) 법률 토글로 전환 (알람은 항상 법률 조문 기준)
+  if (typeof switchLawType === 'function' && currentLawType !== '법률') {
+    switchLawType('법률');
+  }
+  // 2) 조문 이동 (sel.value 설정 + render)
+  if (typeof goArticle === 'function') {
+    goArticle(targetJo);
+  } else {
+    const sel = document.getElementById('sel');
+    if (sel) sel.value = targetJo;
+  }
+  // 3) 연혁 탭으로 전환
+  if (typeof switchTab === 'function') {
+    switchTab('history');
+  }
+  // 4) URL 동기화 (reload 없이) — 새로고침해도 같은 조문 유지
+  try {
+    const url = new URL(window.location.href);
+    url.searchParams.set('jo', targetJo);
+    url.searchParams.set('tab', 'history');
+    url.searchParams.delete('law');
+    history.replaceState(null, '', url.toString());
+  } catch(_) {}
 });
 
 // PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)


### PR DESCRIPTION
## 사용자 보고
viewer [📢 최근 개정 알림] → 모달의 조문 이동 버튼 거의 안 됨.

## 원인
- alarm.html이 `postMessage({type:'goToHistory', jo})` 전송
- 부모 viewer가 `location.href = url` 로 reload 시도
- 그러나 **같은 페이지에 `?jo=` 파라미터만 바뀌면 브라우저가 reload 안 함** → 화면 그대로
- Chrome·Safari·PWA 모두 동일 동작

## 수정 — SPA 방식 직접 함수 호출
```js
1. switchLawType('법률')   // 알람은 항상 법률 조문 기준
2. goArticle(targetJo)     // sel.value 설정 + render
3. switchTab('history')    // 연혁 탭
4. history.replaceState() // URL 동기화 (reload 없이)
```

## Test plan
- [ ] 최근 개정 알림 → 임의 조문 이동 버튼 클릭 → 즉시 해당 조문 연혁 탭 표시
- [ ] 새로고침 시 같은 조문 유지 (URL 동기화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)