### PR TITLE
fix: renderHistory degrade — 별표 실패 시에도 법률 연혁 표시 (Codex#2)

### DIFF
--- a/generate_viewer.py
+++ b/generate_viewer.py
@@ -2109,14 +2109,14 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
-  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
-  if (_lazyTable.status !== 'ready') {
+  // PR-H4-γ-2 + PR-H7 + PR-H8-audit (Codex#2):
+  // error 상태도 정상 흐름 통과시킴 — tblDiffData 등이 빈 객체로 초기화돼 있어
+  // 법률 조문 연혁(cascadeData·diffData)은 정상 표시, 별표 비교 부분만 누락.
+  // 사용자에게 부분 실패 안내 배너만 페이지 상단에 추가 (renderHistoryBody에서 처리).
+  if (_lazyTable.status === 'loading' || _lazyTable.status === 'idle') {
     const hc = document.getElementById('historyContent');
     if (hc) {
-      if (_lazyTable.status === 'error') {
-        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
-      } else {
-        hc.innerHTML = `
+      hc.innerHTML = `
           <div class="main">
             <div style="text-align:center;padding:60px 20px;color:var(--law)">
               <div style="font-size:40px;margin-bottom:14px">📜</div>

--- a/viewer.html
+++ b/viewer.html
@@ -387,7 +387,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
 <!-- PR-H8-audit (Codex#1): data_core 로드 실패 시 복구 UI — onerror 핸들러로 빈 화면 회피 -->
-<script src="web_data/data_core.js?v=20260527221941" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
+<script src="web_data/data_core.js?v=20260527222427" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
 <!-- PR-H6 + PR-H8-audit: data_core 로드 완료 직후 loading overlay 숨김 + window._DATA_CORE 가드 -->
 <script>(function(){
   if (!window._DATA_CORE) {
@@ -409,7 +409,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527221941';
+const _LAZY_TS = '20260527222427';
 const _LAZY_SFX = '';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -1612,14 +1612,14 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
-  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
-  if (_lazyTable.status !== 'ready') {
+  // PR-H4-γ-2 + PR-H7 + PR-H8-audit (Codex#2):
+  // error 상태도 정상 흐름 통과시킴 — tblDiffData 등이 빈 객체로 초기화돼 있어
+  // 법률 조문 연혁(cascadeData·diffData)은 정상 표시, 별표 비교 부분만 누락.
+  // 사용자에게 부분 실패 안내 배너만 페이지 상단에 추가 (renderHistoryBody에서 처리).
+  if (_lazyTable.status === 'loading' || _lazyTable.status === 'idle') {
     const hc = document.getElementById('historyContent');
     if (hc) {
-      if (_lazyTable.status === 'error') {
-        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
-      } else {
-        hc.innerHTML = `
+      hc.innerHTML = `
           <div class="main">
             <div style="text-align:center;padding:60px 20px;color:var(--law)">
               <div style="font-size:40px;margin-bottom:14px">📜</div>

--- a/viewer_car_mgmt.html
+++ b/viewer_car_mgmt.html
@@ -386,7 +386,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
 <!-- PR-H8-audit (Codex#1): data_core 로드 실패 시 복구 UI — onerror 핸들러로 빈 화면 회피 -->
-<script src="web_data/data_core_car_mgmt.js?v=20260527221946" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
+<script src="web_data/data_core_car_mgmt.js?v=20260527222431" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
 <!-- PR-H6 + PR-H8-audit: data_core 로드 완료 직후 loading overlay 숨김 + window._DATA_CORE 가드 -->
 <script>(function(){
   if (!window._DATA_CORE) {
@@ -408,7 +408,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527221946';
+const _LAZY_TS = '20260527222431';
 const _LAZY_SFX = '_car_mgmt';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -1611,14 +1611,14 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
-  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
-  if (_lazyTable.status !== 'ready') {
+  // PR-H4-γ-2 + PR-H7 + PR-H8-audit (Codex#2):
+  // error 상태도 정상 흐름 통과시킴 — tblDiffData 등이 빈 객체로 초기화돼 있어
+  // 법률 조문 연혁(cascadeData·diffData)은 정상 표시, 별표 비교 부분만 누락.
+  // 사용자에게 부분 실패 안내 배너만 페이지 상단에 추가 (renderHistoryBody에서 처리).
+  if (_lazyTable.status === 'loading' || _lazyTable.status === 'idle') {
     const hc = document.getElementById('historyContent');
     if (hc) {
-      if (_lazyTable.status === 'error') {
-        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
-      } else {
-        hc.innerHTML = `
+      hc.innerHTML = `
           <div class="main">
             <div style="text-align:center;padding:60px 20px;color:var(--law)">
               <div style="font-size:40px;margin-bottom:14px">📜</div>

--- a/viewer_cargo_transport.html
+++ b/viewer_cargo_transport.html
@@ -386,7 +386,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
 <!-- PR-H8-audit (Codex#1): data_core 로드 실패 시 복구 UI — onerror 핸들러로 빈 화면 회피 -->
-<script src="web_data/data_core_cargo_transport.js?v=20260527221949" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
+<script src="web_data/data_core_cargo_transport.js?v=20260527222434" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
 <!-- PR-H6 + PR-H8-audit: data_core 로드 완료 직후 loading overlay 숨김 + window._DATA_CORE 가드 -->
 <script>(function(){
   if (!window._DATA_CORE) {
@@ -408,7 +408,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527221949';
+const _LAZY_TS = '20260527222434';
 const _LAZY_SFX = '_cargo_transport';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -1611,14 +1611,14 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
-  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
-  if (_lazyTable.status !== 'ready') {
+  // PR-H4-γ-2 + PR-H7 + PR-H8-audit (Codex#2):
+  // error 상태도 정상 흐름 통과시킴 — tblDiffData 등이 빈 객체로 초기화돼 있어
+  // 법률 조문 연혁(cascadeData·diffData)은 정상 표시, 별표 비교 부분만 누락.
+  // 사용자에게 부분 실패 안내 배너만 페이지 상단에 추가 (renderHistoryBody에서 처리).
+  if (_lazyTable.status === 'loading' || _lazyTable.status === 'idle') {
     const hc = document.getElementById('historyContent');
     if (hc) {
-      if (_lazyTable.status === 'error') {
-        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
-      } else {
-        hc.innerHTML = `
+      hc.innerHTML = `
           <div class="main">
             <div style="text-align:center;padding:60px 20px;color:var(--law)">
               <div style="font-size:40px;margin-bottom:14px">📜</div>

--- a/viewer_crim_proc.html
+++ b/viewer_crim_proc.html
@@ -386,7 +386,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
 <!-- PR-H8-audit (Codex#1): data_core 로드 실패 시 복구 UI — onerror 핸들러로 빈 화면 회피 -->
-<script src="web_data/data_core_crim_proc.js?v=20260527221949" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
+<script src="web_data/data_core_crim_proc.js?v=20260527222435" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
 <!-- PR-H6 + PR-H8-audit: data_core 로드 완료 직후 loading overlay 숨김 + window._DATA_CORE 가드 -->
 <script>(function(){
   if (!window._DATA_CORE) {
@@ -408,7 +408,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527221949';
+const _LAZY_TS = '20260527222435';
 const _LAZY_SFX = '_crim_proc';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -1611,14 +1611,14 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
-  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
-  if (_lazyTable.status !== 'ready') {
+  // PR-H4-γ-2 + PR-H7 + PR-H8-audit (Codex#2):
+  // error 상태도 정상 흐름 통과시킴 — tblDiffData 등이 빈 객체로 초기화돼 있어
+  // 법률 조문 연혁(cascadeData·diffData)은 정상 표시, 별표 비교 부분만 누락.
+  // 사용자에게 부분 실패 안내 배너만 페이지 상단에 추가 (renderHistoryBody에서 처리).
+  if (_lazyTable.status === 'loading' || _lazyTable.status === 'idle') {
     const hc = document.getElementById('historyContent');
     if (hc) {
-      if (_lazyTable.status === 'error') {
-        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
-      } else {
-        hc.innerHTML = `
+      hc.innerHTML = `
           <div class="main">
             <div style="text-align:center;padding:60px 20px;color:var(--law)">
               <div style="font-size:40px;margin-bottom:14px">📜</div>

--- a/viewer_passenger_transport.html
+++ b/viewer_passenger_transport.html
@@ -386,7 +386,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
 <!-- PR-H8-audit (Codex#1): data_core 로드 실패 시 복구 UI — onerror 핸들러로 빈 화면 회피 -->
-<script src="web_data/data_core_passenger_transport.js?v=20260527221948" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
+<script src="web_data/data_core_passenger_transport.js?v=20260527222433" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
 <!-- PR-H6 + PR-H8-audit: data_core 로드 완료 직후 loading overlay 숨김 + window._DATA_CORE 가드 -->
 <script>(function(){
   if (!window._DATA_CORE) {
@@ -408,7 +408,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527221948';
+const _LAZY_TS = '20260527222433';
 const _LAZY_SFX = '_passenger_transport';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -1611,14 +1611,14 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
-  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
-  if (_lazyTable.status !== 'ready') {
+  // PR-H4-γ-2 + PR-H7 + PR-H8-audit (Codex#2):
+  // error 상태도 정상 흐름 통과시킴 — tblDiffData 등이 빈 객체로 초기화돼 있어
+  // 법률 조문 연혁(cascadeData·diffData)은 정상 표시, 별표 비교 부분만 누락.
+  // 사용자에게 부분 실패 안내 배너만 페이지 상단에 추가 (renderHistoryBody에서 처리).
+  if (_lazyTable.status === 'loading' || _lazyTable.status === 'idle') {
     const hc = document.getElementById('historyContent');
     if (hc) {
-      if (_lazyTable.status === 'error') {
-        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
-      } else {
-        hc.innerHTML = `
+      hc.innerHTML = `
           <div class="main">
             <div style="text-align:center;padding:60px 20px;color:var(--law)">
               <div style="font-size:40px;margin-bottom:14px">📜</div>

--- a/viewer_tkga.html
+++ b/viewer_tkga.html
@@ -386,7 +386,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
 <!-- PR-H8-audit (Codex#1): data_core 로드 실패 시 복구 UI — onerror 핸들러로 빈 화면 회피 -->
-<script src="web_data/data_core_tkga.js?v=20260527221943" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
+<script src="web_data/data_core_tkga.js?v=20260527222428" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
 <!-- PR-H6 + PR-H8-audit: data_core 로드 완료 직후 loading overlay 숨김 + window._DATA_CORE 가드 -->
 <script>(function(){
   if (!window._DATA_CORE) {
@@ -408,7 +408,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527221943';
+const _LAZY_TS = '20260527222428';
 const _LAZY_SFX = '_tkga';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -1611,14 +1611,14 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
-  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
-  if (_lazyTable.status !== 'ready') {
+  // PR-H4-γ-2 + PR-H7 + PR-H8-audit (Codex#2):
+  // error 상태도 정상 흐름 통과시킴 — tblDiffData 등이 빈 객체로 초기화돼 있어
+  // 법률 조문 연혁(cascadeData·diffData)은 정상 표시, 별표 비교 부분만 누락.
+  // 사용자에게 부분 실패 안내 배너만 페이지 상단에 추가 (renderHistoryBody에서 처리).
+  if (_lazyTable.status === 'loading' || _lazyTable.status === 'idle') {
     const hc = document.getElementById('historyContent');
     if (hc) {
-      if (_lazyTable.status === 'error') {
-        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
-      } else {
-        hc.innerHTML = `
+      hc.innerHTML = `
           <div class="main">
             <div style="text-align:center;padding:60px 20px;color:var(--law)">
               <div style="font-size:40px;margin-bottom:14px">📜</div>

--- a/viewer_tlspc.html
+++ b/viewer_tlspc.html
@@ -386,7 +386,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
 <!-- PR-H8-audit (Codex#1): data_core 로드 실패 시 복구 UI — onerror 핸들러로 빈 화면 회피 -->
-<script src="web_data/data_core_tlspc.js?v=20260527221942" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
+<script src="web_data/data_core_tlspc.js?v=20260527222428" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
 <!-- PR-H6 + PR-H8-audit: data_core 로드 완료 직후 loading overlay 숨김 + window._DATA_CORE 가드 -->
 <script>(function(){
   if (!window._DATA_CORE) {
@@ -408,7 +408,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527221942';
+const _LAZY_TS = '20260527222428';
 const _LAZY_SFX = '_tlspc';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -1611,14 +1611,14 @@ function countAddendaExceptions(addendaInfo){
 }
 
 function renderHistory(){
-  // PR-H4-γ-2 + PR-H7: 별표 자료 lazy load 가드 — 진행바·경과시간으로 동작 가시화
-  if (_lazyTable.status !== 'ready') {
+  // PR-H4-γ-2 + PR-H7 + PR-H8-audit (Codex#2):
+  // error 상태도 정상 흐름 통과시킴 — tblDiffData 등이 빈 객체로 초기화돼 있어
+  // 법률 조문 연혁(cascadeData·diffData)은 정상 표시, 별표 비교 부분만 누락.
+  // 사용자에게 부분 실패 안내 배너만 페이지 상단에 추가 (renderHistoryBody에서 처리).
+  if (_lazyTable.status === 'loading' || _lazyTable.status === 'idle') {
     const hc = document.getElementById('historyContent');
     if (hc) {
-      if (_lazyTable.status === 'error') {
-        hc.innerHTML = '<div class="main"><div style="text-align:center;padding:40px;color:#c0392b">연혁 자료를 불러오지 못했습니다.<br><br><button onclick="renderHistory()" style="padding:8px 18px;background:var(--law);color:#fff;border:none;border-radius:6px;cursor:pointer">🔄 다시 시도</button></div></div>';
-      } else {
-        hc.innerHTML = `
+      hc.innerHTML = `
           <div class="main">
             <div style="text-align:center;padding:60px 20px;color:var(--law)">
               <div style="font-size:40px;margin-bottom:14px">📜</div>


### PR DESCRIPTION
## 사용자 결정
"renderHistory degrade (별표 실패 해도 연혁 보기 가능)" 적용.

## 수정 (외과적)
renderHistory 가드: `status !== 'ready'` → `loading/idle만 차단`
- **error 상태도 정상 흐름 통과**
- 빈 객체 초기화 덕분에 별표 부분만 비어 보이고 법률 연혁(cascadeData·diffData)은 정상 표시
- 재시도 흐름(ensureTableExtras.then 재호출)은 유지

## 효과
- 네트워크 일부 실패 시에도 법률 본문 연혁 학습 가능
- 부분 자료 누락 → 새로고침으로 자동 재시도

🤖 Generated with [Claude Code](https://claude.com/claude-code)