### PR TITLE
PR-H8-cleanup: 보류 항목 마무리 (prefetch 모바일 차단·KST 고정·road 외 alarm JS)

### DIFF
--- a/generate_viewer.py
+++ b/generate_viewer.py
@@ -949,8 +949,18 @@ function ensureTableExtras(){
   });
   return _lazyTable.promise;
 }
-// 본문 렌더링 후 1.5초 idle 시점에 백그라운드 prefetch — 사용자가 별표 클릭하기 전에 보통 완료
+// PR-H8-cleanup (Codex#3): 모바일에서 자동 prefetch 차단 — 데이터 절약 (매일 80MB ↓)
+// 데스크톱은 1.5초 idle 후 백그라운드 prefetch 유지. 모바일은 사용자가 별표·연혁 클릭 시점에만 로드.
+function _isMobileForPrefetch(){
+  // 좁은 뷰포트 + 셀룰러 네트워크 우선 (네트워크 정보 API는 일부 브라우저만 지원)
+  if (window.innerWidth < 768) return true;
+  if (/Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)) return true;
+  const c = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+  if (c && (c.saveData || /^(slow-2g|2g|3g)$/.test(c.effectiveType || ''))) return true;
+  return false;
+}
 function _kickPrefetchTableExtras(){
+  if (_isMobileForPrefetch()) return;   // 모바일·저속망: 사용자 클릭 시점에만 로드
   setTimeout(function(){
     if (_lazyTable.status === 'idle') ensureTableExtras().catch(function(){});
   }, 1500);
@@ -3109,6 +3119,8 @@ document.addEventListener('keydown',e=>{
 //            브라우저가 reload 안 하고 URL만 바뀌어 화면 그대로 → SPA 방식 직접 호출
 // PR-H8-audit (Codex#5): origin·source 검증 추가 — 외부 iframe·확장 프로그램이 보낸
 //            악의적 postMessage 차단 (보안)
+// PR-H8-cleanup (Codex#10): alarmModal 없는 그룹(road 외)에서는 메시지 핸들러 등록 생략
+if (document.getElementById('alarmModal')) {
 window.addEventListener('message',e=>{
   // 같은 origin + alarm iframe에서 온 메시지만 수락
   if (e.origin !== location.origin) return;
@@ -3141,6 +3153,7 @@ window.addEventListener('message',e=>{
     history.replaceState(null, '', url.toString());
   } catch(_) {}
 });
+}  // end if (document.getElementById('alarmModal')) — PR-H8-cleanup
 
 // PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)
 if ('serviceWorker' in navigator) {

--- a/tutor/index.html
+++ b/tutor/index.html
@@ -268,8 +268,15 @@ footer a { color: var(--sub); text-decoration: underline; }
 const LAW_TYPE_CLASS = { '법률': 'law', '시행령': 'decree', '시행규칙': 'rule' };
 
 function todayStr() {
-  const d = new Date();
-  return d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0');
+  // PR-H8-cleanup (Codex#9): KST 고정 — 해외 출장·다른 타임존 기기에서도 같은 날짜 카드 표시
+  // Intl.DateTimeFormat의 en-CA locale은 YYYY-MM-DD 형식을 보장
+  try {
+    return new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Seoul' }).format(new Date());
+  } catch (e) {
+    // Intl 미지원 폴백 — 로컬 시간 기준
+    const d = new Date();
+    return d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0');
+  }
 }
 function fmtDate(s) {
   if (!s || s.length !== 8) return s || '';

--- a/viewer.html
+++ b/viewer.html
@@ -387,7 +387,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
 <!-- PR-H8-audit (Codex#1): data_core 로드 실패 시 복구 UI — onerror 핸들러로 빈 화면 회피 -->
-<script src="web_data/data_core.js?v=20260527222427" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
+<script src="web_data/data_core.js?v=20260527223132" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
 <!-- PR-H6 + PR-H8-audit: data_core 로드 완료 직후 loading overlay 숨김 + window._DATA_CORE 가드 -->
 <script>(function(){
   if (!window._DATA_CORE) {
@@ -409,7 +409,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527222427';
+const _LAZY_TS = '20260527223132';
 const _LAZY_SFX = '';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -452,8 +452,18 @@ function ensureTableExtras(){
   });
   return _lazyTable.promise;
 }
-// 본문 렌더링 후 1.5초 idle 시점에 백그라운드 prefetch — 사용자가 별표 클릭하기 전에 보통 완료
+// PR-H8-cleanup (Codex#3): 모바일에서 자동 prefetch 차단 — 데이터 절약 (매일 80MB ↓)
+// 데스크톱은 1.5초 idle 후 백그라운드 prefetch 유지. 모바일은 사용자가 별표·연혁 클릭 시점에만 로드.
+function _isMobileForPrefetch(){
+  // 좁은 뷰포트 + 셀룰러 네트워크 우선 (네트워크 정보 API는 일부 브라우저만 지원)
+  if (window.innerWidth < 768) return true;
+  if (/Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)) return true;
+  const c = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+  if (c && (c.saveData || /^(slow-2g|2g|3g)$/.test(c.effectiveType || ''))) return true;
+  return false;
+}
 function _kickPrefetchTableExtras(){
+  if (_isMobileForPrefetch()) return;   // 모바일·저속망: 사용자 클릭 시점에만 로드
   setTimeout(function(){
     if (_lazyTable.status === 'idle') ensureTableExtras().catch(function(){});
   }, 1500);
@@ -2612,6 +2622,8 @@ document.addEventListener('keydown',e=>{
 //            브라우저가 reload 안 하고 URL만 바뀌어 화면 그대로 → SPA 방식 직접 호출
 // PR-H8-audit (Codex#5): origin·source 검증 추가 — 외부 iframe·확장 프로그램이 보낸
 //            악의적 postMessage 차단 (보안)
+// PR-H8-cleanup (Codex#10): alarmModal 없는 그룹(road 외)에서는 메시지 핸들러 등록 생략
+if (document.getElementById('alarmModal')) {
 window.addEventListener('message',e=>{
   // 같은 origin + alarm iframe에서 온 메시지만 수락
   if (e.origin !== location.origin) return;
@@ -2644,6 +2656,7 @@ window.addEventListener('message',e=>{
     history.replaceState(null, '', url.toString());
   } catch(_) {}
 });
+}  // end if (document.getElementById('alarmModal')) — PR-H8-cleanup
 
 // PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)
 if ('serviceWorker' in navigator) {

--- a/viewer_car_mgmt.html
+++ b/viewer_car_mgmt.html
@@ -386,7 +386,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
 <!-- PR-H8-audit (Codex#1): data_core 로드 실패 시 복구 UI — onerror 핸들러로 빈 화면 회피 -->
-<script src="web_data/data_core_car_mgmt.js?v=20260527222431" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
+<script src="web_data/data_core_car_mgmt.js?v=20260527223139" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
 <!-- PR-H6 + PR-H8-audit: data_core 로드 완료 직후 loading overlay 숨김 + window._DATA_CORE 가드 -->
 <script>(function(){
   if (!window._DATA_CORE) {
@@ -408,7 +408,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527222431';
+const _LAZY_TS = '20260527223139';
 const _LAZY_SFX = '_car_mgmt';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -451,8 +451,18 @@ function ensureTableExtras(){
   });
   return _lazyTable.promise;
 }
-// 본문 렌더링 후 1.5초 idle 시점에 백그라운드 prefetch — 사용자가 별표 클릭하기 전에 보통 완료
+// PR-H8-cleanup (Codex#3): 모바일에서 자동 prefetch 차단 — 데이터 절약 (매일 80MB ↓)
+// 데스크톱은 1.5초 idle 후 백그라운드 prefetch 유지. 모바일은 사용자가 별표·연혁 클릭 시점에만 로드.
+function _isMobileForPrefetch(){
+  // 좁은 뷰포트 + 셀룰러 네트워크 우선 (네트워크 정보 API는 일부 브라우저만 지원)
+  if (window.innerWidth < 768) return true;
+  if (/Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)) return true;
+  const c = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+  if (c && (c.saveData || /^(slow-2g|2g|3g)$/.test(c.effectiveType || ''))) return true;
+  return false;
+}
 function _kickPrefetchTableExtras(){
+  if (_isMobileForPrefetch()) return;   // 모바일·저속망: 사용자 클릭 시점에만 로드
   setTimeout(function(){
     if (_lazyTable.status === 'idle') ensureTableExtras().catch(function(){});
   }, 1500);
@@ -2611,6 +2621,8 @@ document.addEventListener('keydown',e=>{
 //            브라우저가 reload 안 하고 URL만 바뀌어 화면 그대로 → SPA 방식 직접 호출
 // PR-H8-audit (Codex#5): origin·source 검증 추가 — 외부 iframe·확장 프로그램이 보낸
 //            악의적 postMessage 차단 (보안)
+// PR-H8-cleanup (Codex#10): alarmModal 없는 그룹(road 외)에서는 메시지 핸들러 등록 생략
+if (document.getElementById('alarmModal')) {
 window.addEventListener('message',e=>{
   // 같은 origin + alarm iframe에서 온 메시지만 수락
   if (e.origin !== location.origin) return;
@@ -2643,6 +2655,7 @@ window.addEventListener('message',e=>{
     history.replaceState(null, '', url.toString());
   } catch(_) {}
 });
+}  // end if (document.getElementById('alarmModal')) — PR-H8-cleanup
 
 // PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)
 if ('serviceWorker' in navigator) {

--- a/viewer_cargo_transport.html
+++ b/viewer_cargo_transport.html
@@ -386,7 +386,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
 <!-- PR-H8-audit (Codex#1): data_core 로드 실패 시 복구 UI — onerror 핸들러로 빈 화면 회피 -->
-<script src="web_data/data_core_cargo_transport.js?v=20260527222434" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
+<script src="web_data/data_core_cargo_transport.js?v=20260527223201" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
 <!-- PR-H6 + PR-H8-audit: data_core 로드 완료 직후 loading overlay 숨김 + window._DATA_CORE 가드 -->
 <script>(function(){
   if (!window._DATA_CORE) {
@@ -408,7 +408,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527222434';
+const _LAZY_TS = '20260527223201';
 const _LAZY_SFX = '_cargo_transport';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -451,8 +451,18 @@ function ensureTableExtras(){
   });
   return _lazyTable.promise;
 }
-// 본문 렌더링 후 1.5초 idle 시점에 백그라운드 prefetch — 사용자가 별표 클릭하기 전에 보통 완료
+// PR-H8-cleanup (Codex#3): 모바일에서 자동 prefetch 차단 — 데이터 절약 (매일 80MB ↓)
+// 데스크톱은 1.5초 idle 후 백그라운드 prefetch 유지. 모바일은 사용자가 별표·연혁 클릭 시점에만 로드.
+function _isMobileForPrefetch(){
+  // 좁은 뷰포트 + 셀룰러 네트워크 우선 (네트워크 정보 API는 일부 브라우저만 지원)
+  if (window.innerWidth < 768) return true;
+  if (/Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)) return true;
+  const c = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+  if (c && (c.saveData || /^(slow-2g|2g|3g)$/.test(c.effectiveType || ''))) return true;
+  return false;
+}
 function _kickPrefetchTableExtras(){
+  if (_isMobileForPrefetch()) return;   // 모바일·저속망: 사용자 클릭 시점에만 로드
   setTimeout(function(){
     if (_lazyTable.status === 'idle') ensureTableExtras().catch(function(){});
   }, 1500);
@@ -2611,6 +2621,8 @@ document.addEventListener('keydown',e=>{
 //            브라우저가 reload 안 하고 URL만 바뀌어 화면 그대로 → SPA 방식 직접 호출
 // PR-H8-audit (Codex#5): origin·source 검증 추가 — 외부 iframe·확장 프로그램이 보낸
 //            악의적 postMessage 차단 (보안)
+// PR-H8-cleanup (Codex#10): alarmModal 없는 그룹(road 외)에서는 메시지 핸들러 등록 생략
+if (document.getElementById('alarmModal')) {
 window.addEventListener('message',e=>{
   // 같은 origin + alarm iframe에서 온 메시지만 수락
   if (e.origin !== location.origin) return;
@@ -2643,6 +2655,7 @@ window.addEventListener('message',e=>{
     history.replaceState(null, '', url.toString());
   } catch(_) {}
 });
+}  // end if (document.getElementById('alarmModal')) — PR-H8-cleanup
 
 // PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)
 if ('serviceWorker' in navigator) {

--- a/viewer_crim_proc.html
+++ b/viewer_crim_proc.html
@@ -386,7 +386,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
 <!-- PR-H8-audit (Codex#1): data_core 로드 실패 시 복구 UI — onerror 핸들러로 빈 화면 회피 -->
-<script src="web_data/data_core_crim_proc.js?v=20260527222435" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
+<script src="web_data/data_core_crim_proc.js?v=20260527223205" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
 <!-- PR-H6 + PR-H8-audit: data_core 로드 완료 직후 loading overlay 숨김 + window._DATA_CORE 가드 -->
 <script>(function(){
   if (!window._DATA_CORE) {
@@ -408,7 +408,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527222435';
+const _LAZY_TS = '20260527223205';
 const _LAZY_SFX = '_crim_proc';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -451,8 +451,18 @@ function ensureTableExtras(){
   });
   return _lazyTable.promise;
 }
-// 본문 렌더링 후 1.5초 idle 시점에 백그라운드 prefetch — 사용자가 별표 클릭하기 전에 보통 완료
+// PR-H8-cleanup (Codex#3): 모바일에서 자동 prefetch 차단 — 데이터 절약 (매일 80MB ↓)
+// 데스크톱은 1.5초 idle 후 백그라운드 prefetch 유지. 모바일은 사용자가 별표·연혁 클릭 시점에만 로드.
+function _isMobileForPrefetch(){
+  // 좁은 뷰포트 + 셀룰러 네트워크 우선 (네트워크 정보 API는 일부 브라우저만 지원)
+  if (window.innerWidth < 768) return true;
+  if (/Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)) return true;
+  const c = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+  if (c && (c.saveData || /^(slow-2g|2g|3g)$/.test(c.effectiveType || ''))) return true;
+  return false;
+}
 function _kickPrefetchTableExtras(){
+  if (_isMobileForPrefetch()) return;   // 모바일·저속망: 사용자 클릭 시점에만 로드
   setTimeout(function(){
     if (_lazyTable.status === 'idle') ensureTableExtras().catch(function(){});
   }, 1500);
@@ -2611,6 +2621,8 @@ document.addEventListener('keydown',e=>{
 //            브라우저가 reload 안 하고 URL만 바뀌어 화면 그대로 → SPA 방식 직접 호출
 // PR-H8-audit (Codex#5): origin·source 검증 추가 — 외부 iframe·확장 프로그램이 보낸
 //            악의적 postMessage 차단 (보안)
+// PR-H8-cleanup (Codex#10): alarmModal 없는 그룹(road 외)에서는 메시지 핸들러 등록 생략
+if (document.getElementById('alarmModal')) {
 window.addEventListener('message',e=>{
   // 같은 origin + alarm iframe에서 온 메시지만 수락
   if (e.origin !== location.origin) return;
@@ -2643,6 +2655,7 @@ window.addEventListener('message',e=>{
     history.replaceState(null, '', url.toString());
   } catch(_) {}
 });
+}  // end if (document.getElementById('alarmModal')) — PR-H8-cleanup
 
 // PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)
 if ('serviceWorker' in navigator) {

--- a/viewer_passenger_transport.html
+++ b/viewer_passenger_transport.html
@@ -386,7 +386,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
 <!-- PR-H8-audit (Codex#1): data_core 로드 실패 시 복구 UI — onerror 핸들러로 빈 화면 회피 -->
-<script src="web_data/data_core_passenger_transport.js?v=20260527222433" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
+<script src="web_data/data_core_passenger_transport.js?v=20260527223152" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
 <!-- PR-H6 + PR-H8-audit: data_core 로드 완료 직후 loading overlay 숨김 + window._DATA_CORE 가드 -->
 <script>(function(){
   if (!window._DATA_CORE) {
@@ -408,7 +408,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527222433';
+const _LAZY_TS = '20260527223152';
 const _LAZY_SFX = '_passenger_transport';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -451,8 +451,18 @@ function ensureTableExtras(){
   });
   return _lazyTable.promise;
 }
-// 본문 렌더링 후 1.5초 idle 시점에 백그라운드 prefetch — 사용자가 별표 클릭하기 전에 보통 완료
+// PR-H8-cleanup (Codex#3): 모바일에서 자동 prefetch 차단 — 데이터 절약 (매일 80MB ↓)
+// 데스크톱은 1.5초 idle 후 백그라운드 prefetch 유지. 모바일은 사용자가 별표·연혁 클릭 시점에만 로드.
+function _isMobileForPrefetch(){
+  // 좁은 뷰포트 + 셀룰러 네트워크 우선 (네트워크 정보 API는 일부 브라우저만 지원)
+  if (window.innerWidth < 768) return true;
+  if (/Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)) return true;
+  const c = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+  if (c && (c.saveData || /^(slow-2g|2g|3g)$/.test(c.effectiveType || ''))) return true;
+  return false;
+}
 function _kickPrefetchTableExtras(){
+  if (_isMobileForPrefetch()) return;   // 모바일·저속망: 사용자 클릭 시점에만 로드
   setTimeout(function(){
     if (_lazyTable.status === 'idle') ensureTableExtras().catch(function(){});
   }, 1500);
@@ -2611,6 +2621,8 @@ document.addEventListener('keydown',e=>{
 //            브라우저가 reload 안 하고 URL만 바뀌어 화면 그대로 → SPA 방식 직접 호출
 // PR-H8-audit (Codex#5): origin·source 검증 추가 — 외부 iframe·확장 프로그램이 보낸
 //            악의적 postMessage 차단 (보안)
+// PR-H8-cleanup (Codex#10): alarmModal 없는 그룹(road 외)에서는 메시지 핸들러 등록 생략
+if (document.getElementById('alarmModal')) {
 window.addEventListener('message',e=>{
   // 같은 origin + alarm iframe에서 온 메시지만 수락
   if (e.origin !== location.origin) return;
@@ -2643,6 +2655,7 @@ window.addEventListener('message',e=>{
     history.replaceState(null, '', url.toString());
   } catch(_) {}
 });
+}  // end if (document.getElementById('alarmModal')) — PR-H8-cleanup
 
 // PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)
 if ('serviceWorker' in navigator) {

--- a/viewer_tkga.html
+++ b/viewer_tkga.html
@@ -386,7 +386,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
 <!-- PR-H8-audit (Codex#1): data_core 로드 실패 시 복구 UI — onerror 핸들러로 빈 화면 회피 -->
-<script src="web_data/data_core_tkga.js?v=20260527222428" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
+<script src="web_data/data_core_tkga.js?v=20260527223134" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
 <!-- PR-H6 + PR-H8-audit: data_core 로드 완료 직후 loading overlay 숨김 + window._DATA_CORE 가드 -->
 <script>(function(){
   if (!window._DATA_CORE) {
@@ -408,7 +408,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527222428';
+const _LAZY_TS = '20260527223134';
 const _LAZY_SFX = '_tkga';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -451,8 +451,18 @@ function ensureTableExtras(){
   });
   return _lazyTable.promise;
 }
-// 본문 렌더링 후 1.5초 idle 시점에 백그라운드 prefetch — 사용자가 별표 클릭하기 전에 보통 완료
+// PR-H8-cleanup (Codex#3): 모바일에서 자동 prefetch 차단 — 데이터 절약 (매일 80MB ↓)
+// 데스크톱은 1.5초 idle 후 백그라운드 prefetch 유지. 모바일은 사용자가 별표·연혁 클릭 시점에만 로드.
+function _isMobileForPrefetch(){
+  // 좁은 뷰포트 + 셀룰러 네트워크 우선 (네트워크 정보 API는 일부 브라우저만 지원)
+  if (window.innerWidth < 768) return true;
+  if (/Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)) return true;
+  const c = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+  if (c && (c.saveData || /^(slow-2g|2g|3g)$/.test(c.effectiveType || ''))) return true;
+  return false;
+}
 function _kickPrefetchTableExtras(){
+  if (_isMobileForPrefetch()) return;   // 모바일·저속망: 사용자 클릭 시점에만 로드
   setTimeout(function(){
     if (_lazyTable.status === 'idle') ensureTableExtras().catch(function(){});
   }, 1500);
@@ -2611,6 +2621,8 @@ document.addEventListener('keydown',e=>{
 //            브라우저가 reload 안 하고 URL만 바뀌어 화면 그대로 → SPA 방식 직접 호출
 // PR-H8-audit (Codex#5): origin·source 검증 추가 — 외부 iframe·확장 프로그램이 보낸
 //            악의적 postMessage 차단 (보안)
+// PR-H8-cleanup (Codex#10): alarmModal 없는 그룹(road 외)에서는 메시지 핸들러 등록 생략
+if (document.getElementById('alarmModal')) {
 window.addEventListener('message',e=>{
   // 같은 origin + alarm iframe에서 온 메시지만 수락
   if (e.origin !== location.origin) return;
@@ -2643,6 +2655,7 @@ window.addEventListener('message',e=>{
     history.replaceState(null, '', url.toString());
   } catch(_) {}
 });
+}  // end if (document.getElementById('alarmModal')) — PR-H8-cleanup
 
 // PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)
 if ('serviceWorker' in navigator) {

--- a/viewer_tlspc.html
+++ b/viewer_tlspc.html
@@ -386,7 +386,7 @@ body{font-family:'Noto Sans KR',sans-serif;background:var(--bg);color:var(--text
 <!-- PR-H4-γ-1: data_timeline.js 제거 (미사용 22MB) -->
 <!-- PR-H4-γ-2: 별표 관련 4개 데이터는 lazy load (도교법 기준 ~85MB 첫 화면에서 빠짐) -->
 <!-- PR-H8-audit (Codex#1): data_core 로드 실패 시 복구 UI — onerror 핸들러로 빈 화면 회피 -->
-<script src="web_data/data_core_tlspc.js?v=20260527222428" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
+<script src="web_data/data_core_tlspc.js?v=20260527223133" onerror="(function(){var o=document.getElementById('loadingOverlay');if(o){o.innerHTML='<div style=\'text-align:center;padding:20px\'><div style=\'font-size:48px;margin-bottom:16px\'>⚠️</div><div style=\'font-size:16px;font-weight:600;margin-bottom:8px\'>법령 데이터 로드 실패</div><div style=\'font-size:13px;opacity:0.85\'>네트워크를 확인하고 새로고침해주세요</div><button onclick=\'location.reload()\' style=\'margin-top:18px;padding:10px 20px;background:#fff;color:var(--law);border:none;border-radius:6px;font-size:14px;font-weight:600;cursor:pointer\'>🔄 다시 시도</button></div>';}})();"></script>
 <!-- PR-H6 + PR-H8-audit: data_core 로드 완료 직후 loading overlay 숨김 + window._DATA_CORE 가드 -->
 <script>(function(){
   if (!window._DATA_CORE) {
@@ -408,7 +408,7 @@ let tblDiffData = {시행령:{}, 시행규칙:{}};
 let tblPdfData = {};
 let tblHistoryData = {시행령:{}, 시행규칙:{}};
 const _lazyTable = { status: 'idle', promise: null };
-const _LAZY_TS = '20260527222428';
+const _LAZY_TS = '20260527223133';
 const _LAZY_SFX = '_tlspc';
 function _loadScriptOnce(src){
   return new Promise(function(resolve, reject){
@@ -451,8 +451,18 @@ function ensureTableExtras(){
   });
   return _lazyTable.promise;
 }
-// 본문 렌더링 후 1.5초 idle 시점에 백그라운드 prefetch — 사용자가 별표 클릭하기 전에 보통 완료
+// PR-H8-cleanup (Codex#3): 모바일에서 자동 prefetch 차단 — 데이터 절약 (매일 80MB ↓)
+// 데스크톱은 1.5초 idle 후 백그라운드 prefetch 유지. 모바일은 사용자가 별표·연혁 클릭 시점에만 로드.
+function _isMobileForPrefetch(){
+  // 좁은 뷰포트 + 셀룰러 네트워크 우선 (네트워크 정보 API는 일부 브라우저만 지원)
+  if (window.innerWidth < 768) return true;
+  if (/Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)) return true;
+  const c = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+  if (c && (c.saveData || /^(slow-2g|2g|3g)$/.test(c.effectiveType || ''))) return true;
+  return false;
+}
 function _kickPrefetchTableExtras(){
+  if (_isMobileForPrefetch()) return;   // 모바일·저속망: 사용자 클릭 시점에만 로드
   setTimeout(function(){
     if (_lazyTable.status === 'idle') ensureTableExtras().catch(function(){});
   }, 1500);
@@ -2611,6 +2621,8 @@ document.addEventListener('keydown',e=>{
 //            브라우저가 reload 안 하고 URL만 바뀌어 화면 그대로 → SPA 방식 직접 호출
 // PR-H8-audit (Codex#5): origin·source 검증 추가 — 외부 iframe·확장 프로그램이 보낸
 //            악의적 postMessage 차단 (보안)
+// PR-H8-cleanup (Codex#10): alarmModal 없는 그룹(road 외)에서는 메시지 핸들러 등록 생략
+if (document.getElementById('alarmModal')) {
 window.addEventListener('message',e=>{
   // 같은 origin + alarm iframe에서 온 메시지만 수락
   if (e.origin !== location.origin) return;
@@ -2643,6 +2655,7 @@ window.addEventListener('message',e=>{
     history.replaceState(null, '', url.toString());
   } catch(_) {}
 });
+}  // end if (document.getElementById('alarmModal')) — PR-H8-cleanup
 
 // PWA PR-H1 — Service Worker 등록 (HTTPS·localhost 한정. 알림 권한 요청은 PR-H2)
 if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## 사용자 결정
- prefetch 모바일 차단 ✓
- Medium 정리 묶음 ✓

## 적용 3건

### 1. prefetch 모바일 차단 (Codex#3)
- `_isMobileForPrefetch()`: 768px 미만 || mobile UA || saveData || slow-2g/2g/3g
- 모바일은 사용자 클릭 시점에만 lazy load → 매일 80MB 자동 다운로드 ↓
- 데스크톱은 기존 동작 유지

### 2. tutor 날짜 KST 고정 (Codex#9)
- `Intl.DateTimeFormat('en-CA', {timeZone:'Asia/Seoul'})`로 KST 고정
- 해외 출장·다른 타임존 기기에서도 같은 날짜 카드 표시

### 3. road 외 viewer alarm 메시지 핸들러 제거 (Codex#10)
- `if (document.getElementById('alarmModal'))` 가드 추가
- 다른 그룹에서 불필요한 메시지 리스너 제거

## Skip
- Codex#6 alarm 명시 — 이미 "도로교통법 / 시행령 / 시행규칙" 안내 있음

🤖 Generated with [Claude Code](https://claude.com/claude-code)