### PR TITLE
PR-H10-β: SW cache-first — viewer 데이터 두 번째 진입 즉시

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,8 +1,10 @@
 // 출근길 법령튜터 PWA Service Worker
 // PR-H1: 기본 등록 + 푸시·알림 클릭 스켈레톤
 // PR-H4에서 알림 표시·진입 흐름 정교화 예정
+// PR-H10-β: viewer web_data/*.js cache-first 전략 — 두 번째 진입부터 네트워크 0
 
-const SW_VERSION = 'pwa-h1-2026-05-26';
+const SW_VERSION = 'pwa-h10-2026-05-28';
+const DATA_CACHE = 'viewer-data-v1';   // ?v= 캐시버스팅이 URL에 포함되므로 새 빌드는 자동 무효화 (새 URL → cache miss → 새 fetch)
 
 self.addEventListener('install', (event) => {
   // 정적 자료는 페이지 자체 캐시버스팅(?v=빌드시각) 사용 — SW는 즉시 활성화
@@ -10,8 +12,48 @@ self.addEventListener('install', (event) => {
 });
 
 self.addEventListener('activate', (event) => {
-  // 이전 SW가 있다면 즉시 교체
-  event.waitUntil(self.clients.claim());
+  // 이전 SW가 있다면 즉시 교체 + 옛 viewer-data-* 캐시 정리
+  event.waitUntil((async () => {
+    try {
+      const names = await caches.keys();
+      await Promise.all(names
+        .filter(n => n.startsWith('viewer-data-') && n !== DATA_CACHE)
+        .map(n => caches.delete(n))
+      );
+    } catch (e) {
+      console.warn('[sw] 옛 캐시 정리 실패:', e);
+    }
+    await self.clients.claim();
+  })());
+});
+
+// PR-H10-β: viewer web_data/*.js cache-first 전략
+// 캐시 키 = URL (?v=빌드TS 포함) → 새 빌드 = 새 URL = 자동 무효화
+// 디스크 정리는 1차에서 보류 (Codex 권장 — 같은 v1 캐시 안 옛 ?v= 항목은 자연스레 hit 없이 잠자도록)
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  let url;
+  try { url = new URL(event.request.url); } catch (e) { return; }
+  if (url.origin !== self.location.origin) return;
+  // /web_data/data_*.js 또는 /road-traffic-law-viewer/web_data/data_*.js (Pages 배포 경로)
+  if (!/\/web_data\/data_.+\.js$/.test(url.pathname)) return;
+
+  event.respondWith((async () => {
+    try {
+      const cache = await caches.open(DATA_CACHE);
+      const hit = await cache.match(event.request);
+      if (hit) return hit;
+      const res = await fetch(event.request);
+      if (res && res.ok) {
+        // quota 초과/cache.put 실패는 silent — 응답은 정상 반환
+        cache.put(event.request, res.clone()).catch(() => {});
+      }
+      return res;
+    } catch (e) {
+      // 캐시 API 자체 실패 (시크릿 모드 등) — 네트워크 폴백
+      return fetch(event.request);
+    }
+  })());
 });
 
 // 푸시 수신 (PR-H3 GitHub Actions에서 web-push로 발송)


### PR DESCRIPTION
## 문제
PR-H10-α가 연혁 첫 진입을 107MB → 16MB로 줄였지만, `?v=빌드TS` 캐시버스팅 + SW fetch 핸들러 부재로 **두 번째 진입도 같은 비용**.

## 변경
service-worker.js 한 파일에 fetch 핸들러 추가:
- `/web_data/data_*.js` 패턴만 가로채 cache-first
- 캐시 이름 `viewer-data-v1` 고정 (URL에 `?v=빌드TS` 포함 → 새 빌드는 자동 무효화)
- activate에서 옛 `viewer-data-*` 캐시 자동 정리

## Codex 교차검증 반영 — 안전 조건
- GET only ✓
- same-origin only ✓
- `/web_data/data_*.js` 패턴 좁게 매칭 — 푸시·알림·정적 자료 무관 ✓
- `response.ok` 일 때만 `cache.put` ✓
- `cache.put` 실패 silent (응답은 정상 반환) ✓
- 캐시 API 자체 실패 시 네트워크 폴백 ✓

## 효과 (α + β 합산)
| 시나리오 | 옛 | α만 | **α+β (최종)** |
|---|---:|---:|---:|
| 연혁 탭 첫 진입 | 107MB | 16.2MB | **16.2MB** |
| 별표 모달 첫 진입 | 0 (이미) | 91MB | **91MB** |
| **두 번째 진입 (같은 빌드)** | 107MB | 16.2MB | **0** |
| 새 빌드 후 첫 진입 | 107MB | 16.2MB | 16.2MB (?v= 변경) |

## 후속 보강 (별도 PR — 보류)
- 같은 v1 캐시 안 옛 `?v=` 항목 정리 (현재 잠자도록 둠 — 설계 단계 합의)
- catch 분기 캐시 실패와 fetch 실패 분리 (오프라인 중복 fetch 1회 회피)

## Test plan
- [ ] PR-H10-α 먼저 머지 + 배포 후 SW 등록 확인
- [ ] PR-H10-β 머지 + Pages 배포 대기
- [ ] DevTools Application → Service Workers → 새 SW 활성화 확인
- [ ] DevTools Application → Cache Storage → `viewer-data-v1` 생성 확인
- [ ] DevTools Network → 첫 연혁 탭 클릭: 16MB 다운로드 (Status 200, 일반)
- [ ] **두 번째 진입** (탭 닫고 다시 열기): Network에서 `(ServiceWorker)` 표시 + Size 0
- [ ] 모바일에서 알람→연혁 체감 속도 개선 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)