### PR TITLE
튜터 날짜 탐색바 가운데 정렬

### DIFF
--- a/tutor/index.html
+++ b/tutor/index.html
@@ -43,7 +43,7 @@ header p { font-size: 13px; opacity: 0.9; }
 header a { color: #ffe; text-decoration: underline; }
 
 .date-nav {
-  display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
+  display: flex; flex-direction: column; align-items: center; gap: 8px;
   background: var(--card); padding: 10px 14px; border-radius: 8px;
   margin-bottom: 14px; box-shadow: var(--shadow); font-size: 13px;
 }
@@ -51,7 +51,7 @@ header a { color: #ffe; text-decoration: underline; }
   padding: 5px 8px; border: 1px solid var(--border); border-radius: 5px;
   font-family: inherit; font-size: 13px;
 }
-.date-nav .today-link { margin-left: auto; color: var(--law); text-decoration: none; font-weight: 500; }
+.date-nav .today-link { color: var(--law); text-decoration: none; font-weight: 500; font-size: 12.5px; }
 .date-nav .today-link:hover { text-decoration: underline; }
 
 /* 2026-05-29: 커스텀 달력 팝오버 */
@@ -62,7 +62,7 @@ header a { color: #ffe; text-decoration: underline; }
 .step-arrow{padding:6px 9px;background:#fff;border:1px solid var(--border);border-radius:6px;cursor:pointer;font-size:14px;font-weight:700;color:var(--law);font-family:inherit;line-height:1}
 .step-arrow:hover{background:#eef2f7;border-color:#93c5fd}
 .step-arrow:active{transform:scale(.92)}
-.date-popover{position:absolute;z-index:100;top:100%;left:50px;background:#fff;border:1px solid var(--border);border-radius:8px;padding:12px;box-shadow:0 8px 24px rgba(0,0,0,0.12);width:280px;margin-top:6px}
+.date-popover{position:absolute;z-index:100;top:100%;left:50%;transform:translateX(-50%);background:#fff;border:1px solid var(--border);border-radius:8px;padding:12px;box-shadow:0 8px 24px rgba(0,0,0,0.12);width:280px;margin-top:6px}
 .dp-head{display:flex;justify-content:space-between;align-items:center;font-weight:700;margin-bottom:8px;color:var(--law);font-size:14px}
 .dp-head button{background:none;border:none;font-size:18px;cursor:pointer;padding:2px 10px;color:var(--law);border-radius:4px;font-family:inherit}
 .dp-head button:hover{background:#f3f4f6}
@@ -91,7 +91,7 @@ header a { color: #ffe; text-decoration: underline; }
 .dp-legend .dot{display:inline-block;width:10px;height:10px;border-radius:50%;margin-right:5px}
 .dp-legend .dot.has{background:#dbeafe;border:1px solid #93c5fd}
 .dp-legend .dot.today{background:#fff;border:2px solid #3b82f6}
-@media (max-width:600px){.date-popover{left:10px;right:10px;width:auto}}
+@media (max-width:600px){.date-popover{left:10px;right:10px;width:auto;transform:none}}
 
 /* 2026-05-29: GPTs Starter 도우미 — 앱에서 starter 안 보이는 문제 우회 */
 .gpts-starter{font-size:12px}
@@ -278,8 +278,7 @@ footer a { color: var(--sub); text-decoration: underline; }
   .card { padding: 18px; }
   .section { padding: 14px 16px; }
   .oneliner { font-size: 18px; }
-  .date-nav { flex-direction: column; align-items: stretch; }
-  .date-nav .today-link { margin-left: 0; text-align: right; }
+  .date-nav { align-items: center; }
 }
 </style>
 </head>
@@ -413,7 +412,6 @@ footer a { color: var(--sub); text-decoration: underline; }
 </div>
 
 <nav class="date-nav" style="position:relative">
-  <label>날짜:</label>
   <span class="date-stepper">
     <button type="button" id="dpStepPrev" class="step-arrow" aria-label="이전 달로" title="이전 달">«</button>
     <button type="button" id="dateBtn" class="date-btn">📅 <span id="dateBtnLabel">오늘</span> ▾</button>


### PR DESCRIPTION
`.date-nav`를 세로·가운데 정렬. `« 📅 날짜 ▾ »` 한 줄 + `오늘 카드로 이동` 아래 줄, 둘 다 가운데.
- `날짜:` 라벨 제거(📅 아이콘 대체, 버튼 텍스트가 접근성 이름)
- 팝오버를 `.date-nav` 기준 가운데로(`left:50%`+`translateX(-50%)`), 모바일 `transform:none`
- Codex 설계 검증 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)