### PR TITLE
튜터: '오늘 카드로 이동' 우측 하단 + 아이콘 📍

### DIFF
--- a/tutor/index.html
+++ b/tutor/index.html
@@ -51,7 +51,7 @@ header a { color: #ffe; text-decoration: underline; }
   padding: 5px 8px; border: 1px solid var(--border); border-radius: 5px;
   font-family: inherit; font-size: 13px;
 }
-.date-nav .today-link { color: var(--law); text-decoration: none; font-weight: 500; font-size: 12.5px; }
+.date-nav .today-link { align-self: flex-end; color: var(--law); text-decoration: none; font-weight: 500; font-size: 12.5px; }
 .date-nav .today-link:hover { text-decoration: underline; }
 
 /* 2026-05-29: 커스텀 달력 팝오버 */
@@ -430,7 +430,7 @@ footer a { color: var(--sub); text-decoration: underline; }
     <div id="dpDays" class="dp-days"></div>
     <div class="dp-legend" id="dpLegend"></div>
   </div>
-  <a href="./" class="today-link">📅 오늘 카드로 이동</a>
+  <a href="./" class="today-link">📍 오늘 카드로 이동</a>
 </nav>
 
 <main id="content">


### PR DESCRIPTION
날짜 버튼(📅)과 아이콘이 중복돼 위아래로 어색하던 문제 해결.
- `.today-link`를 `align-self:flex-end`로 우측 하단 배치(날짜는 가운데 유지)
- 아이콘 📅 → 📍

🤖 Generated with [Claude Code](https://claude.com/claude-code)